### PR TITLE
SFAT-72 - fix to load JSON files from deployed JAR

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/DataLoader.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/DataLoader.java
@@ -1,8 +1,10 @@
 package uk.gov.crowncommercial.dts.scale.service.agreements.repository;
 
-import java.io.File;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,12 +20,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class DataLoader {
 
+	@Autowired
+	ResourceLoader resourceLoader;
+
 	@SuppressWarnings("unchecked")
 	public <T> T convertJsonToObject(String filename, Class<?> target) {
 		try {
 			ObjectMapper objectMapper = new ObjectMapper();
-			File json = new File(getClass().getClassLoader().getResource(filename).getFile());
-			return (T) objectMapper.readValue(json, Class.forName(target.getName()));
+			Resource resource = resourceLoader.getResource("classpath:" + filename);
+			return (T) objectMapper.readValue(resource.getInputStream(), Class.forName(target.getName()));
 		} catch (Exception e) {
 			log.error(e.toString(), e);
 			// RuntimeException is just a convenience for throwaway class
@@ -35,8 +40,8 @@ public class DataLoader {
 
 		try {
 			ObjectMapper objectMapper = new ObjectMapper();
-			File json = new File(getClass().getClassLoader().getResource(filename).getFile());
-			return objectMapper.readValue(json,
+			Resource resource = resourceLoader.getResource("classpath:" + filename);
+			return objectMapper.readValue(resource.getInputStream(),
 					objectMapper.getTypeFactory().constructCollectionType(List.class, Class.forName(target.getName())));
 
 		} catch (Exception e) {


### PR DESCRIPTION
When I tested the Agreements Service in ECS - it was getting errors as it couldn't find the JSON files. Even though worked ok when running locally via maven.

Problem was when running purely from JAR - could replicate locally. Changed the way resources are loaded (this is throwaway code still). Confirmed works ok now. Deployed on SBX1 - sample URL:

https://1ujk7jikie.execute-api.eu-west-2.amazonaws.com/dev/scale/agreements/agreements/RM6154