### PR TITLE
Feature/sinf 361 get agreement lots

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementController.java
@@ -57,7 +57,7 @@ public class AgreementController {
   @GetMapping("/agreements/{ca-number}/lots")
   public Collection<LotDetail> getAgreementLots(
       @PathVariable(value = "ca-number") String caNumber) {
-    log.debug("getAgreementLots: caNumber={", caNumber);
+    log.debug("getAgreementLots: caNumber={}", caNumber);
     // Throw a 404 if agreement number is invalid
     CommercialAgreement ca = service.findAgreementByNumber(caNumber);
     if (ca == null) {

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementController.java
@@ -54,6 +54,20 @@ public class AgreementController {
     return converter.convertAgreementToDTO(ca);
   }
 
+  @GetMapping("/agreements/{ca-number}/lots")
+  public Collection<LotDetail> getAgreementLots(
+      @PathVariable(value = "ca-number") String caNumber) {
+    log.debug("getAgreementLots: caNumber={", caNumber);
+    // Throw a 404 if agreement number is invalid
+    CommercialAgreement ca = service.findAgreementByNumber(caNumber);
+    if (ca == null) {
+      throw new ResourceNotFoundException(
+          String.format("Agreement number '%s' not found", caNumber));
+    }
+    Collection<Lot> lot = service.findLotsByAgreementNumber(caNumber);
+    return converter.convertLotsToDTOs(lot);
+  }
+
   @GetMapping("/agreements/{ca-number}/lots/{lot-number}")
   public LotDetail getLot(@PathVariable(value = "ca-number") String caNumber,
       @PathVariable(value = "lot-number") String lotNumber) {

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/converter/AgreementConverter.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/converter/AgreementConverter.java
@@ -1,5 +1,7 @@
 package uk.gov.crowncommercial.dts.scale.service.agreements.converter;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,6 +48,10 @@ public class AgreementConverter {
 
   public LotDetail convertLotToDTO(Lot lot) {
     return modelMapper.map(lot, LotDetail.class);
+  }
+
+  public Collection<LotDetail> convertLotsToDTOs(Collection<Lot> lots) {
+    return lots.stream().map(l -> modelMapper.map(l, LotDetail.class)).collect(Collectors.toList());
   }
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/LotDetail.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/LotDetail.java
@@ -1,5 +1,6 @@
 package uk.gov.crowncommercial.dts.scale.service.agreements.model.dto;
 
+import java.time.LocalDate;
 import java.util.Collection;
 import lombok.Data;
 
@@ -18,6 +19,16 @@ public class LotDetail {
    * Lot name e.g. "Finance".
    */
   private String name;
+
+  /**
+   * Effective start date of Lot.
+   */
+  private LocalDate startDate;
+
+  /**
+   * Effective end date of Lot.
+   */
+  private LocalDate endDate;
 
   /**
    * Short textual description of the Lot.

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/LotRepo.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/LotRepo.java
@@ -1,5 +1,6 @@
 package uk.gov.crowncommercial.dts.scale.service.agreements.repository;
 
+import java.util.Collection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.Lot;
@@ -11,4 +12,6 @@ import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.Lot;
 public interface LotRepo extends JpaRepository<Lot, Integer> {
 
   Lot findByAgreementNumberAndNumber(String caNumber, String lotNumber);
+
+  Collection<Lot> findByAgreementNumber(String caNumber);
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/AgreementService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/AgreementService.java
@@ -50,7 +50,7 @@ public class AgreementService {
    * @return list of Lots
    */
   public Collection<Lot> findLotsByAgreementNumber(final String caNumber) {
-    log.debug("findLotByAgreementNumberAndLotNumber: caNumber={},lotNumber={}", caNumber);
+    log.debug("findLotsByAgreementNumber: caNumber={}", caNumber);
     return lotRepo.findByAgreementNumber(caNumber);
   }
 

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/AgreementService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/AgreementService.java
@@ -1,5 +1,6 @@
 package uk.gov.crowncommercial.dts.scale.service.agreements.service;
 
+import java.util.Collection;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +41,17 @@ public class AgreementService {
   public CommercialAgreement findAgreementByNumber(final String caNumber) {
     log.debug("findAgreementByNumber: {}", caNumber);
     return commercialAgreementRepo.findByNumber(caNumber);
+  }
+
+  /**
+   * Find all Lots using Agreement Number.
+   * 
+   * @param caNumber Commercial Agreement number
+   * @return list of Lots
+   */
+  public Collection<Lot> findLotsByAgreementNumber(final String caNumber) {
+    log.debug("findLotByAgreementNumberAndLotNumber: caNumber={},lotNumber={}", caNumber);
+    return lotRepo.findByAgreementNumber(caNumber);
   }
 
   /**

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/converter/AgreementConverterTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/converter/AgreementConverterTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -114,10 +116,35 @@ public class AgreementConverterTest {
   @Test
   public void testLotDetailProduct() {
     LotDetail lotDetail = converter.convertLotToDTO(createTestLot("Products"));
+    testLot(lotDetail);
+  }
+
+  @Test
+  public void testLotDetailService() {
+    LotDetail lotDetail = converter.convertLotToDTO(createTestLot("Services"));
+    assertEquals(LotType.SERVICE, lotDetail.getType());
+  }
+
+  @Test
+  public void testLotDetailProductAndService() {
+    LotDetail lotDetail = converter.convertLotToDTO(createTestLot("Products and Services"));
+    assertEquals(LotType.PRODUCT_AND_SERVICE, lotDetail.getType());
+  }
+
+  @Test
+  public void testLotDetailProductCollection() {
+    Collection<LotDetail> lots =
+        converter.convertLotsToDTOs(Arrays.asList(createTestLot("Products")));
+    testLot(lots.stream().findFirst().get());
+  }
+
+  private void testLot(LotDetail lotDetail) {
     assertEquals(LOT_NAME, lotDetail.getName());
     assertEquals(LOT_NUMBER, lotDetail.getNumber());
     assertEquals(LotType.PRODUCT, lotDetail.getType());
     assertEquals(LOT_DESCRIPTION, lotDetail.getDescription());
+    assertEquals(START_DATE, lotDetail.getStartDate());
+    assertEquals(END_DATE, lotDetail.getEndDate());
 
     String sector = lotDetail.getSectors().stream().findFirst().get();
     assertEquals(SECTOR_NAME, sector);
@@ -147,18 +174,6 @@ public class AgreementConverterTest {
     assertEquals(RELATED_AGREEMENT_NUMBER, related.getCaNumber());
     assertEquals(RELATED_LOT_NUMBER, related.getLotNumber());
     assertEquals(RELATED_LOT_RELATIONSHIP, related.getRelationship());
-  }
-
-  @Test
-  public void testLotDetailService() {
-    LotDetail lotDetail = converter.convertLotToDTO(createTestLot("Services"));
-    assertEquals(LotType.SERVICE, lotDetail.getType());
-  }
-
-  @Test
-  public void testLotDetailProductAndService() {
-    LotDetail lotDetail = converter.convertLotToDTO(createTestLot("Products and Services"));
-    assertEquals(LotType.PRODUCT_AND_SERVICE, lotDetail.getType());
   }
 
   private Lot createTestLot(String type) {


### PR DESCRIPTION
Added the get-agreement-lots endpoint.

Had to add 2 calls in the controller - first one to check Agreement existed in order to throw a 404 (as per the spec). The repo would just return an empty list if either the agreement number was valid and there were no lots or if the agreement number was invalid. There may be a more elegant way to do this (but I couldn't find).

This is a non-breaking update, but just thinking might be an opportune moment to create a tag (and possibly update maven release number) on develop before merging these new changes - will discuss offline.