### PR TITLE
Feature/as 55 error codes

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/GlobalErrorHandler.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/GlobalErrorHandler.java
@@ -24,10 +24,9 @@ import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.ApiErrors;
 @Slf4j
 public class GlobalErrorHandler implements ErrorController {
 
-  public static final String ERR_MSG_VALIDATION = "Validation error processing the request";
-  public static final String ERR_MSG_NOT_FOUND = "Resource not found";
-
+  public static final String ERR_MSG_VALIDATION_TITLE = "Validation error processing the request";
   public static final String ERR_MSG_VALIDATION_DESCRIPTION = "Invalid request";
+  public static final String ERR_MSG_NOT_FOUND_TITLE = "Resource not found";
   public static final String ERR_MSG_NOT_FOUND_DESCRIPTION =
       "The resource you were looking for could not be found";
   public static final String ERR_MSG_UNKNOWN_DESCRIPTION = "An unknown error has occurred";
@@ -45,7 +44,7 @@ public class GlobalErrorHandler implements ErrorController {
     }
 
     final ApiError apiError =
-        new ApiError(HttpStatus.BAD_REQUEST.toString(), ERR_MSG_VALIDATION, detail);
+        new ApiError(HttpStatus.BAD_REQUEST.toString(), ERR_MSG_VALIDATION_TITLE, detail);
     return new ApiErrors(Arrays.asList(apiError), ERR_MSG_VALIDATION_DESCRIPTION);
   }
 
@@ -55,8 +54,8 @@ public class GlobalErrorHandler implements ErrorController {
 
     log.trace("Resource not found exception", exception);
 
-    final ApiError apiError =
-        new ApiError(HttpStatus.NOT_FOUND.toString(), ERR_MSG_NOT_FOUND, exception.getMessage());
+    final ApiError apiError = new ApiError(HttpStatus.NOT_FOUND.toString(), ERR_MSG_NOT_FOUND_TITLE,
+        exception.getMessage());
     return new ApiErrors(Arrays.asList(apiError), ERR_MSG_NOT_FOUND_DESCRIPTION);
   }
 

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/GlobalErrorHandler.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/GlobalErrorHandler.java
@@ -13,7 +13,6 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.crowncommercial.dts.scale.service.agreements.exception.AgreementNotFoundException;
 import uk.gov.crowncommercial.dts.scale.service.agreements.exception.LotNotFoundException;
-import uk.gov.crowncommercial.dts.scale.service.agreements.exception.MethodNotImplementedException;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.ApiError;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.ApiErrors;
 
@@ -29,6 +28,11 @@ public class GlobalErrorHandler implements ErrorController {
   public static final String ERR_MSG_VALIDATION = "Validation error processing the request";
   public static final String ERR_MSG_NOT_FOUND = "Resource not found";
 
+  public static final String ERR_MSG_VALIDATION_DESCRIPTION = "Invalid request";
+  public static final String ERR_MSG_NOT_FOUND_DESCRIPTION =
+      "The resource you were looking for could not be found";
+  public static final String ERR_MSG_UNKNOWN_DESCRIPTION = "An unknown error has occurred";
+
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler({ValidationException.class, HttpMessageNotReadableException.class,
       MethodArgumentTypeMismatchException.class})
@@ -43,7 +47,7 @@ public class GlobalErrorHandler implements ErrorController {
 
     final ApiError apiError =
         new ApiError(HttpStatus.BAD_REQUEST.toString(), ERR_MSG_VALIDATION, detail);
-    return new ApiErrors(Arrays.asList(apiError));
+    return new ApiErrors(Arrays.asList(apiError), ERR_MSG_VALIDATION_DESCRIPTION);
   }
 
   @ResponseStatus(HttpStatus.NOT_FOUND)
@@ -54,18 +58,7 @@ public class GlobalErrorHandler implements ErrorController {
 
     final ApiError apiError =
         new ApiError(HttpStatus.NOT_FOUND.toString(), ERR_MSG_NOT_FOUND, exception.getMessage());
-    return new ApiErrors(Arrays.asList(apiError));
-  }
-
-  @ResponseStatus(HttpStatus.METHOD_NOT_ALLOWED)
-  @ExceptionHandler(MethodNotImplementedException.class)
-  public ApiErrors handleMethodNotImplementedException(final Exception exception) {
-
-    log.trace("Method not implemented", exception);
-
-    final ApiError apiError = new ApiError(HttpStatus.METHOD_NOT_ALLOWED.toString(),
-        ERR_MSG_NOT_FOUND, exception.getMessage());
-    return new ApiErrors(Arrays.asList(apiError));
+    return new ApiErrors(Arrays.asList(apiError), ERR_MSG_NOT_FOUND_DESCRIPTION);
   }
 
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
@@ -73,10 +66,7 @@ public class GlobalErrorHandler implements ErrorController {
   public ApiErrors handleUnknownException(final Exception exception) {
 
     log.error("Unknown application exception", exception);
-
-    final ApiError apiError =
-        new ApiError(HttpStatus.INTERNAL_SERVER_ERROR.toString(), ERR_MSG_DEFAULT, "");
-    return new ApiErrors(Arrays.asList(apiError));
+    return new ApiErrors(null, ERR_MSG_UNKNOWN_DESCRIPTION);
   }
 
   @GetMapping(value = "/error")
@@ -87,8 +77,11 @@ public class GlobalErrorHandler implements ErrorController {
 
     log.error("Unknown container/filter exception", exception);
 
-    return ResponseEntity.badRequest().body(new ApiErrors(Arrays
-        .asList(new ApiError(HttpStatus.INTERNAL_SERVER_ERROR.toString(), ERR_MSG_DEFAULT, ""))));
+    return ResponseEntity.badRequest()
+        .body(new ApiErrors(
+            Arrays.asList(
+                new ApiError(HttpStatus.INTERNAL_SERVER_ERROR.toString(), ERR_MSG_DEFAULT, "")),
+            "DESC"));
   }
 
   @Override

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/GlobalErrorHandler.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/GlobalErrorHandler.java
@@ -29,7 +29,7 @@ public class GlobalErrorHandler implements ErrorController {
   public static final String ERR_MSG_NOT_FOUND_TITLE = "Resource not found";
   public static final String ERR_MSG_NOT_FOUND_DESCRIPTION =
       "The resource you were looking for could not be found";
-  public static final String ERR_MSG_UNKNOWN_DESCRIPTION = "An unknown error has occurred";
+  public static final String ERR_MSG_DEFAULT_DESCRIPTION = "An unknown error has occurred";
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler({ValidationException.class, HttpMessageNotReadableException.class,
@@ -64,7 +64,7 @@ public class GlobalErrorHandler implements ErrorController {
   public ApiErrors handleUnknownException(final Exception exception) {
 
     log.error("Unknown application exception", exception);
-    return new ApiErrors(null, ERR_MSG_UNKNOWN_DESCRIPTION);
+    return new ApiErrors(null, ERR_MSG_DEFAULT_DESCRIPTION);
   }
 
   @GetMapping(value = "/error")
@@ -75,7 +75,7 @@ public class GlobalErrorHandler implements ErrorController {
 
     log.error("Unknown container/filter exception", exception);
 
-    return ResponseEntity.badRequest().body(new ApiErrors(null, ERR_MSG_UNKNOWN_DESCRIPTION));
+    return ResponseEntity.badRequest().body(new ApiErrors(null, ERR_MSG_DEFAULT_DESCRIPTION));
   }
 
   @Override

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/GlobalErrorHandler.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/GlobalErrorHandler.java
@@ -24,7 +24,6 @@ import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.ApiErrors;
 @Slf4j
 public class GlobalErrorHandler implements ErrorController {
 
-  public static final String ERR_MSG_DEFAULT = "An error occurred processing the request";
   public static final String ERR_MSG_VALIDATION = "Validation error processing the request";
   public static final String ERR_MSG_NOT_FOUND = "Resource not found";
 
@@ -77,11 +76,7 @@ public class GlobalErrorHandler implements ErrorController {
 
     log.error("Unknown container/filter exception", exception);
 
-    return ResponseEntity.badRequest()
-        .body(new ApiErrors(
-            Arrays.asList(
-                new ApiError(HttpStatus.INTERNAL_SERVER_ERROR.toString(), ERR_MSG_DEFAULT, "")),
-            "DESC"));
+    return ResponseEntity.badRequest().body(new ApiErrors(null, ERR_MSG_UNKNOWN_DESCRIPTION));
   }
 
   @Override

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/ApiErrors.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/ApiErrors.java
@@ -10,4 +10,6 @@ import lombok.Data;
 public class ApiErrors {
 
   private final List<ApiError> errors;
+  private final String description;
+
 }

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementControllerTest.java
@@ -118,7 +118,7 @@ class AgreementControllerTest {
         .thenThrow(new RuntimeException("Something is amiss"));
     mockMvc.perform(get(String.format(GET_AGREEMENT_PATH, AGREEMENT_NUMBER)))
         .andExpect(status().is5xxServerError())
-        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_UNKNOWN_DESCRIPTION)));
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_DEFAULT_DESCRIPTION)));
   }
 
   @Test
@@ -191,7 +191,7 @@ class AgreementControllerTest {
         .thenThrow(new RuntimeException("Something is amiss"));
     mockMvc.perform(get(String.format(GET_AGREEMENT_LOTS_PATH, AGREEMENT_NUMBER)))
         .andExpect(status().is5xxServerError())
-        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_UNKNOWN_DESCRIPTION)));
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_DEFAULT_DESCRIPTION)));
   }
 
   @Test
@@ -226,7 +226,7 @@ class AgreementControllerTest {
         .thenThrow(new RuntimeException("Something is amiss"));
     mockMvc.perform(get(String.format(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_NUMBER)))
         .andExpect(status().is5xxServerError())
-        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_UNKNOWN_DESCRIPTION)));
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_DEFAULT_DESCRIPTION)));
   }
 
   @Test
@@ -276,7 +276,7 @@ class AgreementControllerTest {
         .thenThrow(new RuntimeException("Something is amiss"));
     mockMvc.perform(get(String.format(GET_AGREEMENT_DOCUMENTS_PATH, AGREEMENT_NUMBER)))
         .andExpect(status().is5xxServerError())
-        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_UNKNOWN_DESCRIPTION)));
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_DEFAULT_DESCRIPTION)));
   }
 
   @Test
@@ -310,7 +310,7 @@ class AgreementControllerTest {
         .thenThrow(new RuntimeException("Something is amiss"));
     mockMvc.perform(get(String.format(GET_AGREEMENT_UPDATES_PATH, AGREEMENT_NUMBER)))
         .andExpect(status().is5xxServerError())
-        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_UNKNOWN_DESCRIPTION)));
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_DEFAULT_DESCRIPTION)));
   }
 
   @Test

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementControllerTest.java
@@ -108,7 +108,8 @@ class AgreementControllerTest {
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
         .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND)))
         .andExpect(jsonPath("$.errors[0].detail",
-            is(String.format(AgreementNotFoundException.ERROR_MSG_TEMPLATE, AGREEMENT_NUMBER))));
+            is(String.format(AgreementNotFoundException.ERROR_MSG_TEMPLATE, AGREEMENT_NUMBER))))
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
   }
 
   @Test
@@ -117,8 +118,7 @@ class AgreementControllerTest {
         .thenThrow(new RuntimeException("Something is amiss"));
     mockMvc.perform(get(String.format(GET_AGREEMENT_PATH, AGREEMENT_NUMBER)))
         .andExpect(status().is5xxServerError())
-        .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.INTERNAL_SERVER_ERROR.toString())))
-        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_DEFAULT)));
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_UNKNOWN_DESCRIPTION)));
   }
 
   @Test
@@ -168,7 +168,9 @@ class AgreementControllerTest {
         .andExpect(jsonPath("$.errors[0].status", is("400 BAD_REQUEST")))
         .andExpect(jsonPath("$.errors[0].title", is("Validation error processing the request")))
         .andExpect(jsonPath("$.errors[0].detail", is(
-            "Buying method value invalid. Valid values are: [DirectAward, FurtherCompetition, Marketplace, EAuction]")));
+            "Buying method value invalid. Valid values are: [DirectAward, FurtherCompetition, Marketplace, EAuction]")))
+        .andExpect(
+            jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_VALIDATION_DESCRIPTION)));
   }
 
   @Test
@@ -179,7 +181,8 @@ class AgreementControllerTest {
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
         .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND)))
         .andExpect(jsonPath("$.errors[0].detail",
-            is(String.format(AgreementNotFoundException.ERROR_MSG_TEMPLATE, AGREEMENT_NUMBER))));
+            is(String.format(AgreementNotFoundException.ERROR_MSG_TEMPLATE, AGREEMENT_NUMBER))))
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
   }
 
   @Test
@@ -188,8 +191,7 @@ class AgreementControllerTest {
         .thenThrow(new RuntimeException("Something is amiss"));
     mockMvc.perform(get(String.format(GET_AGREEMENT_LOTS_PATH, AGREEMENT_NUMBER)))
         .andExpect(status().is5xxServerError())
-        .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.INTERNAL_SERVER_ERROR.toString())))
-        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_DEFAULT)));
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_UNKNOWN_DESCRIPTION)));
   }
 
   @Test
@@ -212,8 +214,10 @@ class AgreementControllerTest {
         .andExpect(status().is4xxClientError())
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
         .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND)))
-        .andExpect(jsonPath("$.errors[0].detail", is(String
-            .format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_NUMBER, AGREEMENT_NUMBER))));
+        .andExpect(jsonPath("$.errors[0].detail",
+            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_NUMBER,
+                AGREEMENT_NUMBER))))
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
   }
 
   @Test
@@ -222,8 +226,7 @@ class AgreementControllerTest {
         .thenThrow(new RuntimeException("Something is amiss"));
     mockMvc.perform(get(String.format(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_NUMBER)))
         .andExpect(status().is5xxServerError())
-        .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.INTERNAL_SERVER_ERROR.toString())))
-        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_DEFAULT)));
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_UNKNOWN_DESCRIPTION)));
   }
 
   @Test
@@ -263,7 +266,8 @@ class AgreementControllerTest {
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
         .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND)))
         .andExpect(jsonPath("$.errors[0].detail",
-            is(String.format(AgreementNotFoundException.ERROR_MSG_TEMPLATE, AGREEMENT_NUMBER))));
+            is(String.format(AgreementNotFoundException.ERROR_MSG_TEMPLATE, AGREEMENT_NUMBER))))
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
   }
 
   @Test
@@ -272,8 +276,7 @@ class AgreementControllerTest {
         .thenThrow(new RuntimeException("Something is amiss"));
     mockMvc.perform(get(String.format(GET_AGREEMENT_DOCUMENTS_PATH, AGREEMENT_NUMBER)))
         .andExpect(status().is5xxServerError())
-        .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.INTERNAL_SERVER_ERROR.toString())))
-        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_DEFAULT)));
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_UNKNOWN_DESCRIPTION)));
   }
 
   @Test
@@ -297,7 +300,8 @@ class AgreementControllerTest {
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
         .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND)))
         .andExpect(jsonPath("$.errors[0].detail",
-            is(String.format(AgreementNotFoundException.ERROR_MSG_TEMPLATE, AGREEMENT_NUMBER))));
+            is(String.format(AgreementNotFoundException.ERROR_MSG_TEMPLATE, AGREEMENT_NUMBER))))
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
   }
 
   @Test
@@ -306,8 +310,7 @@ class AgreementControllerTest {
         .thenThrow(new RuntimeException("Something is amiss"));
     mockMvc.perform(get(String.format(GET_AGREEMENT_UPDATES_PATH, AGREEMENT_NUMBER)))
         .andExpect(status().is5xxServerError())
-        .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.INTERNAL_SERVER_ERROR.toString())))
-        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_DEFAULT)));
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_UNKNOWN_DESCRIPTION)));
   }
 
   @Test
@@ -352,7 +355,9 @@ class AgreementControllerTest {
         .andExpect(status().is4xxClientError())
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
         .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND)))
-        .andExpect(jsonPath("$.errors[0].detail", is(String
-            .format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_NUMBER, AGREEMENT_NUMBER))));
+        .andExpect(jsonPath("$.errors[0].detail",
+            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_NUMBER,
+                AGREEMENT_NUMBER))))
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
   }
 }

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementControllerTest.java
@@ -106,7 +106,7 @@ class AgreementControllerTest {
     mockMvc.perform(get(String.format(GET_AGREEMENT_PATH, AGREEMENT_NUMBER)))
         .andExpect(status().is4xxClientError())
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
-        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND)))
+        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
         .andExpect(jsonPath("$.errors[0].detail",
             is(String.format(AgreementNotFoundException.ERROR_MSG_TEMPLATE, AGREEMENT_NUMBER))))
         .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
@@ -179,7 +179,7 @@ class AgreementControllerTest {
     mockMvc.perform(get(String.format(GET_AGREEMENT_LOTS_PATH, AGREEMENT_NUMBER)))
         .andExpect(status().is4xxClientError())
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
-        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND)))
+        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
         .andExpect(jsonPath("$.errors[0].detail",
             is(String.format(AgreementNotFoundException.ERROR_MSG_TEMPLATE, AGREEMENT_NUMBER))))
         .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
@@ -213,7 +213,7 @@ class AgreementControllerTest {
     mockMvc.perform(get(String.format(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_NUMBER)))
         .andExpect(status().is4xxClientError())
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
-        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND)))
+        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
         .andExpect(jsonPath("$.errors[0].detail",
             is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_NUMBER,
                 AGREEMENT_NUMBER))))
@@ -264,7 +264,7 @@ class AgreementControllerTest {
     mockMvc.perform(get(String.format(GET_AGREEMENT_DOCUMENTS_PATH, AGREEMENT_NUMBER)))
         .andExpect(status().is4xxClientError())
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
-        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND)))
+        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
         .andExpect(jsonPath("$.errors[0].detail",
             is(String.format(AgreementNotFoundException.ERROR_MSG_TEMPLATE, AGREEMENT_NUMBER))))
         .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
@@ -298,7 +298,7 @@ class AgreementControllerTest {
     mockMvc.perform(get(String.format(GET_AGREEMENT_UPDATES_PATH, AGREEMENT_NUMBER)))
         .andExpect(status().is4xxClientError())
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
-        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND)))
+        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
         .andExpect(jsonPath("$.errors[0].detail",
             is(String.format(AgreementNotFoundException.ERROR_MSG_TEMPLATE, AGREEMENT_NUMBER))))
         .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
@@ -354,7 +354,7 @@ class AgreementControllerTest {
     mockMvc.perform(get(GET_LOT_SUPPLIERS_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
         .andExpect(status().is4xxClientError())
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
-        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND)))
+        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
         .andExpect(jsonPath("$.errors[0].detail",
             is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_NUMBER,
                 AGREEMENT_NUMBER))))


### PR DESCRIPTION
Updated error formats to match OpenAPI spec (the 500 error omits any error details, presumably by design to hide any internal info...(?)) - so tried to match that here.

There will be a corresponding infra PR to update the error formats returned by API Gateway