### PR TITLE
Feature/scc 442 event types

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementController.java
@@ -12,11 +12,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.crowncommercial.dts.scale.service.agreements.converter.AgreementConverter;
 import uk.gov.crowncommercial.dts.scale.service.agreements.exception.AgreementNotFoundException;
-import uk.gov.crowncommercial.dts.scale.service.agreements.exception.LotNotFoundException;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.*;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.CommercialAgreement;
-import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.Lot;
-import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.LotOrganisationRole;
 import uk.gov.crowncommercial.dts.scale.service.agreements.service.AgreementService;
 
 /**
@@ -27,8 +24,6 @@ import uk.gov.crowncommercial.dts.scale.service.agreements.service.AgreementServ
 @RequiredArgsConstructor
 @Slf4j
 public class AgreementController {
-
-  static final String METHOD_NOT_IMPLEMENTED_MSG = "This method is not yet implemented by the API";
 
   private final AgreementService service;
   private final AgreementConverter converter;
@@ -63,17 +58,6 @@ public class AgreementController {
     }
   }
 
-  @GetMapping("/agreements/{ca-number}/lots/{lot-number}")
-  public LotDetail getLot(@PathVariable(value = "ca-number") final String caNumber,
-      @PathVariable(value = "lot-number") final String lotNumber) {
-    log.debug("getLot: caNumber={},lotNumber={}", caNumber, lotNumber);
-    final Lot lot = service.findLotByAgreementNumberAndLotNumber(caNumber, lotNumber);
-    if (lot == null) {
-      throw new LotNotFoundException(lotNumber, caNumber);
-    }
-    return converter.convertLotToDTO(lot);
-  }
-
   @GetMapping("/agreements/{ca-number}/documents")
   public Collection<Document> getAgreementDocuments(
       @PathVariable(value = "ca-number") final String caNumber) {
@@ -88,19 +72,6 @@ public class AgreementController {
     log.debug("getAgreementUpdates: {}", caNumber);
     final CommercialAgreement ca = getAgreement(caNumber);
     return converter.convertAgreementUpdatesToDTOs(ca.getUpdates());
-  }
-
-  @GetMapping("/agreements/{ca-number}/lots/{lot-number}/suppliers")
-  public Collection<LotSupplier> getLotSuppliers(
-      @PathVariable(value = "ca-number") final String caNumber,
-      @PathVariable(value = "lot-number") final String lotNumber) {
-
-    log.debug("getLotSuppliers: caNumber={}, lotNumber={}", caNumber, lotNumber);
-
-    final Collection<LotOrganisationRole> lotOrgRoles =
-        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(caNumber, lotNumber);
-
-    return converter.convertLotOrgRolesToLotSupplierDTOs(lotOrgRoles);
   }
 
   private CommercialAgreement getAgreement(final String caNumber) {

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementController.java
@@ -4,10 +4,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.crowncommercial.dts.scale.service.agreements.converter.AgreementConverter;
@@ -21,6 +18,7 @@ import uk.gov.crowncommercial.dts.scale.service.agreements.service.AgreementServ
  *
  */
 @RestController
+@RequestMapping("/agreements")
 @RequiredArgsConstructor
 @Slf4j
 public class AgreementController {
@@ -28,7 +26,7 @@ public class AgreementController {
   private final AgreementService service;
   private final AgreementConverter converter;
 
-  @GetMapping("/agreements")
+  @GetMapping
   public Collection<AgreementSummary> getAgreements() {
     log.debug("getAgreements");
     final List<CommercialAgreement> agreements = service.getAgreements();
@@ -36,7 +34,7 @@ public class AgreementController {
         .collect(Collectors.toList());
   }
 
-  @GetMapping("/agreements/{agreement-id}")
+  @GetMapping("/{agreement-id}")
   public AgreementDetail getAgreementDetail(
       @PathVariable(value = "agreement-id") final String agreementId) {
     log.debug("getAgreement: {}", agreementId);
@@ -44,7 +42,7 @@ public class AgreementController {
     return converter.convertAgreementToDTO(ca);
   }
 
-  @GetMapping("/agreements/{agreement-id}/lots")
+  @GetMapping("/{agreement-id}/lots")
   public Collection<LotDetail> getAgreementLots(
       @PathVariable(value = "agreement-id") final String agreementId,
       @RequestParam Optional<BuyingMethod> buyingMethod) {
@@ -58,7 +56,7 @@ public class AgreementController {
     }
   }
 
-  @GetMapping("/agreements/{agreement-id}/documents")
+  @GetMapping("/{agreement-id}/documents")
   public Collection<Document> getAgreementDocuments(
       @PathVariable(value = "agreement-id") final String agreementId) {
     log.debug("getAgreementDocuments: {}", agreementId);
@@ -66,7 +64,7 @@ public class AgreementController {
     return converter.convertAgreementDocumentsToDTOs(ca.getDocuments());
   }
 
-  @GetMapping("/agreements/{agreement-id}/updates")
+  @GetMapping("/{agreement-id}/updates")
   public Collection<AgreementUpdate> getAgreementUpdates(
       @PathVariable(value = "agreement-id") final String agreementId) {
     log.debug("getAgreementUpdates: {}", agreementId);

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementController.java
@@ -36,20 +36,20 @@ public class AgreementController {
         .collect(Collectors.toList());
   }
 
-  @GetMapping("/agreements/{ca-number}")
+  @GetMapping("/agreements/{agreement-id}")
   public AgreementDetail getAgreementDetail(
-      @PathVariable(value = "ca-number") final String caNumber) {
-    log.debug("getAgreement: {}", caNumber);
-    final CommercialAgreement ca = getAgreement(caNumber);
+      @PathVariable(value = "agreement-id") final String agreementId) {
+    log.debug("getAgreement: {}", agreementId);
+    final CommercialAgreement ca = getAgreement(agreementId);
     return converter.convertAgreementToDTO(ca);
   }
 
-  @GetMapping("/agreements/{ca-number}/lots")
+  @GetMapping("/agreements/{agreement-id}/lots")
   public Collection<LotDetail> getAgreementLots(
-      @PathVariable(value = "ca-number") final String caNumber,
+      @PathVariable(value = "agreement-id") final String agreementId,
       @RequestParam Optional<BuyingMethod> buyingMethod) {
-    log.debug("getAgreementLots: caNumber={}, buyingMethod={}", caNumber, buyingMethod);
-    final CommercialAgreement ca = getAgreement(caNumber);
+    log.debug("getAgreementLots: agreementId={}, buyingMethod={}", agreementId, buyingMethod);
+    final CommercialAgreement ca = getAgreement(agreementId);
     Collection<LotDetail> lots = converter.convertLotsToDTOs(ca.getLots());
     if (buyingMethod.isPresent()) {
       return filterLotsByBuyingMethod(lots, buyingMethod.get());
@@ -58,19 +58,19 @@ public class AgreementController {
     }
   }
 
-  @GetMapping("/agreements/{ca-number}/documents")
+  @GetMapping("/agreements/{agreement-id}/documents")
   public Collection<Document> getAgreementDocuments(
-      @PathVariable(value = "ca-number") final String caNumber) {
-    log.debug("getAgreementDocuments: {}", caNumber);
-    final CommercialAgreement ca = getAgreement(caNumber);
+      @PathVariable(value = "agreement-id") final String agreementId) {
+    log.debug("getAgreementDocuments: {}", agreementId);
+    final CommercialAgreement ca = getAgreement(agreementId);
     return converter.convertAgreementDocumentsToDTOs(ca.getDocuments());
   }
 
-  @GetMapping("/agreements/{ca-number}/updates")
+  @GetMapping("/agreements/{agreement-id}/updates")
   public Collection<AgreementUpdate> getAgreementUpdates(
-      @PathVariable(value = "ca-number") final String caNumber) {
-    log.debug("getAgreementUpdates: {}", caNumber);
-    final CommercialAgreement ca = getAgreement(caNumber);
+      @PathVariable(value = "agreement-id") final String agreementId) {
+    log.debug("getAgreementUpdates: {}", agreementId);
+    final CommercialAgreement ca = getAgreement(agreementId);
     return converter.convertAgreementUpdatesToDTOs(ca.getUpdates());
   }
 

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotController.java
@@ -27,40 +27,40 @@ public class LotController {
   private final AgreementService service;
   private final AgreementConverter converter;
 
-  @GetMapping("/agreements/{ca-number}/lots/{lot-number}")
-  public LotDetail getLot(@PathVariable(value = "ca-number") final String caNumber,
-      @PathVariable(value = "lot-number") final String lotNumber) {
-    log.debug("getLot: caNumber={},lotNumber={}", caNumber, lotNumber);
-    final Lot lot = service.findLotByAgreementNumberAndLotNumber(caNumber, lotNumber);
+  @GetMapping("/agreements/{agreement-id}/lots/{lot-id}")
+  public LotDetail getLot(@PathVariable(value = "agreement-id") final String agreementId,
+      @PathVariable(value = "lot-id") final String lotId) {
+    log.debug("getLot: agreementId={},lotId={}", agreementId, lotId);
+    final Lot lot = service.findLotByAgreementNumberAndLotNumber(agreementId, lotId);
     if (lot == null) {
-      throw new LotNotFoundException(lotNumber, caNumber);
+      throw new LotNotFoundException(lotId, agreementId);
     }
     return converter.convertLotToDTO(lot);
   }
 
-  @GetMapping("/agreements/{ca-number}/lots/{lot-number}/suppliers")
+  @GetMapping("/agreements/{agreement-id}/lots/{lot-id}/suppliers")
   public Collection<LotSupplier> getLotSuppliers(
-      @PathVariable(value = "ca-number") final String caNumber,
-      @PathVariable(value = "lot-number") final String lotNumber) {
+      @PathVariable(value = "agreement-id") final String agreementId,
+      @PathVariable(value = "lot-id") final String lotId) {
 
-    log.debug("getLotSuppliers: caNumber={}, lotNumber={}", caNumber, lotNumber);
+    log.debug("getLotSuppliers: agreementId={}, lotId={}", agreementId, lotId);
 
     final Collection<LotOrganisationRole> lotOrgRoles =
-        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(caNumber, lotNumber);
+        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(agreementId, lotId);
 
     return converter.convertLotOrgRolesToLotSupplierDTOs(lotOrgRoles);
   }
 
-  @GetMapping("/agreements/{ca-number}/lots/{lot-number}/event-types")
+  @GetMapping("/agreements/{agreement-id}/lots/{lot-id}/event-types")
   public Collection<EventType> getLotEventTypes(
-      @PathVariable(value = "ca-number") final String caNumber,
-      @PathVariable(value = "lot-number") final String lotNumber) {
+      @PathVariable(value = "agreement-id") final String agreementId,
+      @PathVariable(value = "lot-id") final String lotId) {
 
-    log.debug("getLotEventTypes: caNumber={}, lotNumber={}", caNumber, lotNumber);
+    log.debug("getLotEventTypes: agreementId={}, lotId={}", agreementId, lotId);
 
-    final Lot lot = service.findLotByAgreementNumberAndLotNumber(caNumber, lotNumber);
+    final Lot lot = service.findLotByAgreementNumberAndLotNumber(agreementId, lotId);
     if (lot == null) {
-      throw new LotNotFoundException(lotNumber, caNumber);
+      throw new LotNotFoundException(lotId, agreementId);
     }
 
     return converter.convertLotProcurementEventTypesToDTOs(lot.getProcurementEventTypes());

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotController.java
@@ -1,0 +1,69 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.controller;
+
+import java.util.Collection;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import uk.gov.crowncommercial.dts.scale.service.agreements.converter.AgreementConverter;
+import uk.gov.crowncommercial.dts.scale.service.agreements.exception.LotNotFoundException;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.EventType;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.LotDetail;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.LotSupplier;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.Lot;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.LotOrganisationRole;
+import uk.gov.crowncommercial.dts.scale.service.agreements.service.AgreementService;
+
+/**
+ * Lot Controller.
+ *
+ */
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class LotController {
+
+  private final AgreementService service;
+  private final AgreementConverter converter;
+
+  @GetMapping("/agreements/{ca-number}/lots/{lot-number}")
+  public LotDetail getLot(@PathVariable(value = "ca-number") final String caNumber,
+      @PathVariable(value = "lot-number") final String lotNumber) {
+    log.debug("getLot: caNumber={},lotNumber={}", caNumber, lotNumber);
+    final Lot lot = service.findLotByAgreementNumberAndLotNumber(caNumber, lotNumber);
+    if (lot == null) {
+      throw new LotNotFoundException(lotNumber, caNumber);
+    }
+    return converter.convertLotToDTO(lot);
+  }
+
+  @GetMapping("/agreements/{ca-number}/lots/{lot-number}/suppliers")
+  public Collection<LotSupplier> getLotSuppliers(
+      @PathVariable(value = "ca-number") final String caNumber,
+      @PathVariable(value = "lot-number") final String lotNumber) {
+
+    log.debug("getLotSuppliers: caNumber={}, lotNumber={}", caNumber, lotNumber);
+
+    final Collection<LotOrganisationRole> lotOrgRoles =
+        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(caNumber, lotNumber);
+
+    return converter.convertLotOrgRolesToLotSupplierDTOs(lotOrgRoles);
+  }
+
+  @GetMapping("/agreements/{ca-number}/lots/{lot-number}/event-types")
+  public Collection<EventType> getLotEventTypes(
+      @PathVariable(value = "ca-number") final String caNumber,
+      @PathVariable(value = "lot-number") final String lotNumber) {
+
+    log.debug("getLotEventTypes: caNumber={}, lotNumber={}", caNumber, lotNumber);
+
+    final Lot lot = service.findLotByAgreementNumberAndLotNumber(caNumber, lotNumber);
+    if (lot == null) {
+      throw new LotNotFoundException(lotNumber, caNumber);
+    }
+
+    return converter.convertLotProcurementEventTypesToDTOs(lot.getProcurementEventTypes());
+  }
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotController.java
@@ -3,6 +3,7 @@ package uk.gov.crowncommercial.dts.scale.service.agreements.controller;
 import java.util.Collection;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,6 +21,7 @@ import uk.gov.crowncommercial.dts.scale.service.agreements.service.AgreementServ
  *
  */
 @RestController
+@RequestMapping("/agreements/{agreement-id}/lots/{lot-id}")
 @RequiredArgsConstructor
 @Slf4j
 public class LotController {
@@ -27,7 +29,7 @@ public class LotController {
   private final AgreementService service;
   private final AgreementConverter converter;
 
-  @GetMapping("/agreements/{agreement-id}/lots/{lot-id}")
+  @GetMapping
   public LotDetail getLot(@PathVariable(value = "agreement-id") final String agreementId,
       @PathVariable(value = "lot-id") final String lotId) {
     log.debug("getLot: agreementId={},lotId={}", agreementId, lotId);
@@ -38,7 +40,7 @@ public class LotController {
     return converter.convertLotToDTO(lot);
   }
 
-  @GetMapping("/agreements/{agreement-id}/lots/{lot-id}/suppliers")
+  @GetMapping("/suppliers")
   public Collection<LotSupplier> getLotSuppliers(
       @PathVariable(value = "agreement-id") final String agreementId,
       @PathVariable(value = "lot-id") final String lotId) {
@@ -51,7 +53,7 @@ public class LotController {
     return converter.convertLotOrgRolesToLotSupplierDTOs(lotOrgRoles);
   }
 
-  @GetMapping("/agreements/{agreement-id}/lots/{lot-id}/event-types")
+  @GetMapping("/event-types")
   public Collection<EventType> getLotEventTypes(
       @PathVariable(value = "agreement-id") final String agreementId,
       @PathVariable(value = "lot-id") final String lotId) {

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/converter/AgreementConverter.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/converter/AgreementConverter.java
@@ -32,6 +32,7 @@ public class AgreementConverter {
   private final TimestampConverter timestampConverter;
   private final AgreementOwnerConverter agreementOwnerConverter;
   private final AgreementBenefitConverter agreementBenefitConverter;
+  private final EventTypeConverter eventTypeConverter;
 
   @PostConstruct
   public void init() {
@@ -43,6 +44,7 @@ public class AgreementConverter {
     modelMapper.addConverter(agreementUpdateConverter);
     modelMapper.addConverter(routeToMarketConverter);
     modelMapper.addConverter(timestampConverter);
+    modelMapper.addConverter(eventTypeConverter);
 
     /*
      * Specific mismatched properties / converters (do not set globally on modelMapper)
@@ -89,6 +91,12 @@ public class AgreementConverter {
   public Collection<LotSupplier> convertLotOrgRolesToLotSupplierDTOs(
       final Collection<LotOrganisationRole> lotOrgRoles) {
     return lotOrgRoles.stream().map(lor -> modelMapper.map(lor, LotSupplier.class))
+        .collect(Collectors.toSet());
+  }
+
+  public Collection<EventType> convertLotProcurementEventTypesToDTOs(
+      final Collection<LotProcurementEventType> lotProcurementEventTypes) {
+    return lotProcurementEventTypes.stream().map(lpet -> modelMapper.map(lpet, EventType.class))
         .collect(Collectors.toSet());
   }
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/converter/EventTypeConverter.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/converter/EventTypeConverter.java
@@ -1,0 +1,26 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.converter;
+
+import org.modelmapper.AbstractConverter;
+import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.EventType;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.LotProcurementEventType;
+
+/**
+ * Converts LotProcurementEventType from database into EventType.
+ *
+ */
+@RequiredArgsConstructor
+@Component
+public class EventTypeConverter extends AbstractConverter<LotProcurementEventType, EventType> {
+
+  @Override
+  protected EventType convert(LotProcurementEventType lotProcurementEventType) {
+    EventType eventType = new EventType();
+    eventType.setType(lotProcurementEventType.getProcurementEventType().getName());
+    // TODO: Description needs to be added to the database table - see SCAT-1767
+    // eventType.setDescription(null);
+    return eventType;
+  }
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/EventType.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/EventType.java
@@ -1,0 +1,15 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.model.dto;
+
+import lombok.Data;
+
+/**
+ * EventType
+ */
+@Data
+public class EventType {
+
+  private String type;
+
+  private String description;
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/Lot.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/Lot.java
@@ -66,4 +66,8 @@ public class Lot {
   @OneToMany(fetch = FetchType.LAZY)
   @JoinColumn(name = "lot_id")
   Set<LotOrganisationRole> organisationRoles;
+
+  @OneToMany
+  @JoinColumn(name = "lot_id")
+  Set<LotProcurementEventType> procurementEventTypes;
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/Lot.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/Lot.java
@@ -67,7 +67,7 @@ public class Lot {
   @JoinColumn(name = "lot_id")
   Set<LotOrganisationRole> organisationRoles;
 
-  @OneToMany
+  @OneToMany(fetch = FetchType.LAZY)
   @JoinColumn(name = "lot_id")
   Set<LotProcurementEventType> procurementEventTypes;
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/LotProcurementEventType.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/LotProcurementEventType.java
@@ -7,7 +7,7 @@ import lombok.Data;
 import lombok.experimental.FieldDefaults;
 
 /**
- * Procurement Event Type.
+ * Lot Procurement Event Type.
  */
 @Entity
 @Immutable

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/LotProcurementEventType.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/LotProcurementEventType.java
@@ -1,0 +1,32 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.model.entity;
+
+import javax.persistence.*;
+import org.hibernate.annotations.Immutable;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * Procurement Event Type.
+ */
+@Entity
+@Immutable
+@Table(name = "lot_procurement_event_types")
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class LotProcurementEventType {
+
+  @EmbeddedId
+  LotProcurementEventTypeKey key;
+
+  @MapsId("procurementEventTypeId")
+  @ManyToOne
+  @JoinColumn(name = "procurement_event_type_id")
+  ProcurementEventType procurementEventType;
+
+  @Column(name = "mandatory_event_ind")
+  Boolean isMandatoryEvent;
+
+  @Column(name = "repeatable_event_ind")
+  Boolean isRepeatableEvent;
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/LotProcurementEventTypeKey.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/LotProcurementEventTypeKey.java
@@ -19,5 +19,4 @@ public class LotProcurementEventTypeKey implements Serializable {
 
   @Column(name = "procurement_event_type_id")
   Integer procurementEventTypeId;
-
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/LotProcurementEventTypeKey.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/LotProcurementEventTypeKey.java
@@ -1,0 +1,23 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.model.entity;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import lombok.Data;
+
+/**
+ * Compound Key.
+ */
+@Data
+@Embeddable
+public class LotProcurementEventTypeKey implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @Column(name = "lot_id")
+  Integer lotId;
+
+  @Column(name = "procurement_event_type_id")
+  Integer procurementEventTypeId;
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/ProcurementEventType.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/ProcurementEventType.java
@@ -1,0 +1,28 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.model.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import org.hibernate.annotations.Immutable;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * Lot Procurement Event Type.
+ */
+@Entity
+@Immutable
+@Table(name = "procurement_event_types")
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ProcurementEventType {
+
+  @Id
+  @Column(name = "procurement_event_type_id")
+  Integer id;
+
+  @Column(name = "procurement_event_type_name")
+  String name;
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/ProcurementEventType.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/ProcurementEventType.java
@@ -10,7 +10,7 @@ import lombok.Data;
 import lombok.experimental.FieldDefaults;
 
 /**
- * Lot Procurement Event Type.
+ * Procurement Event Type.
  */
 @Entity
 @Immutable

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementControllerTest.java
@@ -3,12 +3,10 @@ package uk.gov.crowncommercial.dts.scale.service.agreements.controller;
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -17,11 +15,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.crowncommercial.dts.scale.service.agreements.converter.AgreementConverter;
 import uk.gov.crowncommercial.dts.scale.service.agreements.exception.AgreementNotFoundException;
-import uk.gov.crowncommercial.dts.scale.service.agreements.exception.LotNotFoundException;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.*;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.*;
 import uk.gov.crowncommercial.dts.scale.service.agreements.service.AgreementService;
@@ -31,12 +27,9 @@ import uk.gov.crowncommercial.dts.scale.service.agreements.service.AgreementServ
 class AgreementControllerTest {
 
   private static final String GET_AGREEMENT_PATH = "/agreements/%s";
-  private static final String GET_LOT_PATH = "/agreements/%s/lots/%s";
   private static final String GET_AGREEMENT_LOTS_PATH = "/agreements/%s/lots";
   private static final String GET_AGREEMENT_DOCUMENTS_PATH = "/agreements/%s/documents";
   private static final String GET_AGREEMENT_UPDATES_PATH = "/agreements/%s/updates";
-  private static final String GET_LOT_SUPPLIERS_PATH =
-      "/agreements/{ca-number}/lots/{lot-number}/suppliers";
   private static final String BUYING_METHOD_PARAM = "buyingMethod";
   private static final String BUYING_METHOD_VALUE = "EAuction";
 
@@ -195,41 +188,6 @@ class AgreementControllerTest {
   }
 
   @Test
-  void testGetLotSuccess() throws Exception {
-    final LotDetail lot = new LotDetail();
-    lot.setNumber(LOT1_NUMBER);
-
-    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
-        .thenReturn(mockLot);
-    when(converter.convertLotToDTO(mockLot)).thenReturn(lot);
-    mockMvc.perform(get(String.format(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_NUMBER)))
-        .andExpect(status().isOk()).andExpect(jsonPath("$.number", is(LOT1_NUMBER)));
-  }
-
-  @Test
-  void testGetLotNotFound() throws Exception {
-    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
-        .thenReturn(null);
-    mockMvc.perform(get(String.format(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_NUMBER)))
-        .andExpect(status().is4xxClientError())
-        .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
-        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
-        .andExpect(jsonPath("$.errors[0].detail",
-            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_NUMBER,
-                AGREEMENT_NUMBER))))
-        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
-  }
-
-  @Test
-  void testGetLotUnexpectedError() throws Exception {
-    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
-        .thenThrow(new RuntimeException("Something is amiss"));
-    mockMvc.perform(get(String.format(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_NUMBER)))
-        .andExpect(status().is5xxServerError())
-        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_DEFAULT_DESCRIPTION)));
-  }
-
-  @Test
   void testGetAgreementDocuments() throws Exception {
     final Document document = new Document();
     document.setName(DOCUMENT_NAME);
@@ -313,51 +271,5 @@ class AgreementControllerTest {
         .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_DEFAULT_DESCRIPTION)));
   }
 
-  @Test
-  void testGetLotSuppliers() throws Exception {
-    final Set<LotOrganisationRole> lotOrgRoles = Collections.singleton(lotOrganisationRole);
 
-    final Organization org = new Organization();
-    org.setName("ABC Ltd");
-    final ContactPoint contactPoint = new ContactPoint();
-    contactPoint.setName("Procurement");
-    final Contact contact = new Contact();
-    contact.setContactId("abc123");
-    contact.setContactPoint(contactPoint);
-    final LotSupplier lotSupplier = new LotSupplier();
-    lotSupplier.setOrganization(org);
-    lotSupplier.setSupplierStatus(SupplierStatus.ACTIVE);
-    lotSupplier.setLotContacts(Collections.singleton(contact));
-
-    when(
-        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
-            .thenReturn(lotOrgRoles);
-    when(converter.convertLotOrgRolesToLotSupplierDTOs(lotOrgRoles))
-        .thenReturn(Collections.singleton(lotSupplier));
-
-    mockMvc.perform(get(GET_LOT_SUPPLIERS_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().is2xxSuccessful()).andExpect(jsonPath("$.size()", is(1)))
-        .andExpect(jsonPath("$.[0].organization.name", is("ABC Ltd")))
-        .andExpect(jsonPath("$.[0].supplierStatus", is("active")))
-        .andExpect(jsonPath("$.[0].lotContacts.size()", is(1)))
-        .andExpect(jsonPath("$.[0].lotContacts.[0].contactId", is("abc123")))
-        .andExpect(jsonPath("$.[0].lotContacts.[0].contact.name", is("Procurement")));
-  }
-
-  @Test
-  void testGetLotSuppliersNotFound() throws Exception {
-    when(
-        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
-            .thenThrow(new LotNotFoundException(LOT1_NUMBER, AGREEMENT_NUMBER));
-
-    mockMvc.perform(get(GET_LOT_SUPPLIERS_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
-        .andExpect(status().is4xxClientError())
-        .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
-        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
-        .andExpect(jsonPath("$.errors[0].detail",
-            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_NUMBER,
-                AGREEMENT_NUMBER))))
-        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
-  }
 }

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementControllerTest.java
@@ -34,8 +34,8 @@ class AgreementControllerTest {
   private static final String BUYING_METHOD_VALUE = "EAuction";
 
   private static final String AGREEMENT_NUMBER = "RM3733";
-  private static final String LOT1_NUMBER = "Lot 1";
-  private static final String LOT2_NUMBER = "Lot 2";
+  private static final String LOT1_ID = "Lot 1";
+  private static final String LOT2_ID = "Lot 2";
   private static final String AGREEMENT_UPDATE_TEXT = "Update Text";
 
   private static final String DOCUMENT_NAME = "My Doc";
@@ -117,13 +117,13 @@ class AgreementControllerTest {
   @Test
   void testGetAgreementLotsSuccess() throws Exception {
     final LotDetail lot = new LotDetail();
-    lot.setNumber(LOT1_NUMBER);
+    lot.setNumber(LOT1_ID);
     final Set<Lot> mockLots = new HashSet<>(Arrays.asList(mockLot));
     when(service.findAgreementByNumber(AGREEMENT_NUMBER)).thenReturn(mockCommercialAgreement);
     when(mockCommercialAgreement.getLots()).thenReturn(mockLots);
     when(converter.convertLotsToDTOs(mockLots)).thenReturn(Arrays.asList(lot));
     mockMvc.perform(get(String.format(GET_AGREEMENT_LOTS_PATH, AGREEMENT_NUMBER)))
-        .andExpect(status().isOk()).andExpect(jsonPath("$[0].number", is(LOT1_NUMBER)));
+        .andExpect(status().isOk()).andExpect(jsonPath("$[0].number", is(LOT1_ID)));
   }
 
   @Test
@@ -131,14 +131,14 @@ class AgreementControllerTest {
     final LotDetail lot1 = new LotDetail();
     final RouteToMarketDTO directAward = new RouteToMarketDTO();
     directAward.setBuyingMethod(BuyingMethod.DIRECT_AWARD);
-    lot1.setNumber(LOT1_NUMBER);
+    lot1.setNumber(LOT1_ID);
     lot1.setRoutesToMarket(Arrays.asList(directAward));
 
     final LotDetail lot2 = new LotDetail();
     final RouteToMarketDTO furtherCompetition = new RouteToMarketDTO();
     final RouteToMarketDTO eAuction = new RouteToMarketDTO();
     furtherCompetition.setBuyingMethod(BuyingMethod.E_AUCTION);
-    lot2.setNumber(LOT2_NUMBER);
+    lot2.setNumber(LOT2_ID);
     lot2.setRoutesToMarket(Arrays.asList(furtherCompetition, eAuction));
 
     final Set<Lot> mockLots = new HashSet<>(Arrays.asList(mockLot));
@@ -149,7 +149,7 @@ class AgreementControllerTest {
         .perform(get(String.format(GET_AGREEMENT_LOTS_PATH, AGREEMENT_NUMBER))
             .queryParam(BUYING_METHOD_PARAM, BUYING_METHOD_VALUE))
         .andExpect(status().isOk()).andExpect(jsonPath("$.size()", is(1)))
-        .andExpect(jsonPath("$[0].number", is(LOT2_NUMBER)));
+        .andExpect(jsonPath("$[0].number", is(LOT2_ID)));
   }
 
   @Test

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementControllerTest.java
@@ -34,8 +34,8 @@ class AgreementControllerTest {
   private static final String BUYING_METHOD_VALUE = "EAuction";
 
   private static final String AGREEMENT_NUMBER = "RM3733";
-  private static final String LOT1_ID = "Lot 1";
-  private static final String LOT2_ID = "Lot 2";
+  private static final String LOT1_NUMBER = "Lot 1";
+  private static final String LOT2_NUMBER = "Lot 2";
   private static final String AGREEMENT_UPDATE_TEXT = "Update Text";
 
   private static final String DOCUMENT_NAME = "My Doc";
@@ -117,13 +117,13 @@ class AgreementControllerTest {
   @Test
   void testGetAgreementLotsSuccess() throws Exception {
     final LotDetail lot = new LotDetail();
-    lot.setNumber(LOT1_ID);
+    lot.setNumber(LOT1_NUMBER);
     final Set<Lot> mockLots = new HashSet<>(Arrays.asList(mockLot));
     when(service.findAgreementByNumber(AGREEMENT_NUMBER)).thenReturn(mockCommercialAgreement);
     when(mockCommercialAgreement.getLots()).thenReturn(mockLots);
     when(converter.convertLotsToDTOs(mockLots)).thenReturn(Arrays.asList(lot));
     mockMvc.perform(get(String.format(GET_AGREEMENT_LOTS_PATH, AGREEMENT_NUMBER)))
-        .andExpect(status().isOk()).andExpect(jsonPath("$[0].number", is(LOT1_ID)));
+        .andExpect(status().isOk()).andExpect(jsonPath("$[0].number", is(LOT1_NUMBER)));
   }
 
   @Test
@@ -131,14 +131,14 @@ class AgreementControllerTest {
     final LotDetail lot1 = new LotDetail();
     final RouteToMarketDTO directAward = new RouteToMarketDTO();
     directAward.setBuyingMethod(BuyingMethod.DIRECT_AWARD);
-    lot1.setNumber(LOT1_ID);
+    lot1.setNumber(LOT1_NUMBER);
     lot1.setRoutesToMarket(Arrays.asList(directAward));
 
     final LotDetail lot2 = new LotDetail();
     final RouteToMarketDTO furtherCompetition = new RouteToMarketDTO();
     final RouteToMarketDTO eAuction = new RouteToMarketDTO();
     furtherCompetition.setBuyingMethod(BuyingMethod.E_AUCTION);
-    lot2.setNumber(LOT2_ID);
+    lot2.setNumber(LOT2_NUMBER);
     lot2.setRoutesToMarket(Arrays.asList(furtherCompetition, eAuction));
 
     final Set<Lot> mockLots = new HashSet<>(Arrays.asList(mockLot));
@@ -149,7 +149,7 @@ class AgreementControllerTest {
         .perform(get(String.format(GET_AGREEMENT_LOTS_PATH, AGREEMENT_NUMBER))
             .queryParam(BUYING_METHOD_PARAM, BUYING_METHOD_VALUE))
         .andExpect(status().isOk()).andExpect(jsonPath("$.size()", is(1)))
-        .andExpect(jsonPath("$[0].number", is(LOT2_ID)));
+        .andExpect(jsonPath("$[0].number", is(LOT2_NUMBER)));
   }
 
   @Test

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotControllerTest.java
@@ -33,7 +33,7 @@ class LotControllerTest {
       "/agreements/{agreement-id}/lots/{lot-id}/event-types";
 
   private static final String AGREEMENT_NUMBER = "RM3733";
-  private static final String LOT1_NUMBER = "Lot 1";
+  private static final String LOT1_ID = "Lot 1";
 
   @Autowired
   private MockMvc mockMvc;
@@ -65,34 +65,34 @@ class LotControllerTest {
   @Test
   void testGetLotSuccess() throws Exception {
     final LotDetail lot = new LotDetail();
-    lot.setNumber(LOT1_NUMBER);
+    lot.setNumber(LOT1_ID);
 
-    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
+    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_ID))
         .thenReturn(mockLot);
     when(converter.convertLotToDTO(mockLot)).thenReturn(lot);
-    mockMvc.perform(get(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_NUMBER)).andExpect(status().isOk())
-        .andExpect(jsonPath("$.number", is(LOT1_NUMBER)));
+    mockMvc.perform(get(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_ID)).andExpect(status().isOk())
+        .andExpect(jsonPath("$.number", is(LOT1_ID)));
   }
 
   @Test
   void testGetLotNotFound() throws Exception {
-    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
+    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_ID))
         .thenReturn(null);
-    mockMvc.perform(get(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
+    mockMvc.perform(get(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_ID))
         .andExpect(status().is4xxClientError())
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
         .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
         .andExpect(jsonPath("$.errors[0].detail",
-            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_NUMBER,
+            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_ID,
                 AGREEMENT_NUMBER))))
         .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
   }
 
   @Test
   void testGetLotUnexpectedError() throws Exception {
-    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
+    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_ID))
         .thenThrow(new RuntimeException("Something is amiss"));
-    mockMvc.perform(get(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
+    mockMvc.perform(get(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_ID))
         .andExpect(status().is5xxServerError())
         .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_DEFAULT_DESCRIPTION)));
   }
@@ -114,12 +114,12 @@ class LotControllerTest {
     lotSupplier.setLotContacts(Collections.singleton(contact));
 
     when(
-        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
+        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_ID))
             .thenReturn(lotOrgRoles);
     when(converter.convertLotOrgRolesToLotSupplierDTOs(lotOrgRoles))
         .thenReturn(Collections.singleton(lotSupplier));
 
-    mockMvc.perform(get(GET_LOT_SUPPLIERS_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
+    mockMvc.perform(get(GET_LOT_SUPPLIERS_PATH, AGREEMENT_NUMBER, LOT1_ID))
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful()).andExpect(jsonPath("$.size()", is(1)))
         .andExpect(jsonPath("$.[0].organization.name", is("ABC Ltd")))
@@ -132,15 +132,15 @@ class LotControllerTest {
   @Test
   void testGetLotSuppliersNotFound() throws Exception {
     when(
-        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
-            .thenThrow(new LotNotFoundException(LOT1_NUMBER, AGREEMENT_NUMBER));
+        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_ID))
+            .thenThrow(new LotNotFoundException(LOT1_ID, AGREEMENT_NUMBER));
 
-    mockMvc.perform(get(GET_LOT_SUPPLIERS_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
+    mockMvc.perform(get(GET_LOT_SUPPLIERS_PATH, AGREEMENT_NUMBER, LOT1_ID))
         .andExpect(status().is4xxClientError())
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
         .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
         .andExpect(jsonPath("$.errors[0].detail",
-            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_NUMBER,
+            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_ID,
                 AGREEMENT_NUMBER))))
         .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
   }
@@ -153,13 +153,13 @@ class LotControllerTest {
     EventType eventType = new EventType();
     eventType.setType("RFI");
 
-    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
+    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_ID))
         .thenReturn(mockLot);
     when(mockLot.getProcurementEventTypes()).thenReturn(lotProcurementEventTypes);
     when(converter.convertLotProcurementEventTypesToDTOs(lotProcurementEventTypes))
         .thenReturn(Collections.singleton(eventType));
 
-    mockMvc.perform(get(GET_LOT_EVENT_TYPES_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
+    mockMvc.perform(get(GET_LOT_EVENT_TYPES_PATH, AGREEMENT_NUMBER, LOT1_ID))
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful()).andExpect(jsonPath("$.size()", is(1)))
         .andExpect(jsonPath("$.[0].type", is("RFI")));
@@ -167,14 +167,14 @@ class LotControllerTest {
 
   @Test
   void testGetLotEventTypesNotFound() throws Exception {
-    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
+    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_ID))
         .thenReturn(null);
-    mockMvc.perform(get(GET_LOT_EVENT_TYPES_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
+    mockMvc.perform(get(GET_LOT_EVENT_TYPES_PATH, AGREEMENT_NUMBER, LOT1_ID))
         .andExpect(status().is4xxClientError())
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
         .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
         .andExpect(jsonPath("$.errors[0].detail",
-            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_NUMBER,
+            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_ID,
                 AGREEMENT_NUMBER))))
         .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
   }

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotControllerTest.java
@@ -33,7 +33,7 @@ class LotControllerTest {
       "/agreements/{agreement-id}/lots/{lot-id}/event-types";
 
   private static final String AGREEMENT_NUMBER = "RM3733";
-  private static final String LOT1_ID = "Lot 1";
+  private static final String LOT1_NUMBER = "Lot 1";
 
   @Autowired
   private MockMvc mockMvc;
@@ -65,34 +65,34 @@ class LotControllerTest {
   @Test
   void testGetLotSuccess() throws Exception {
     final LotDetail lot = new LotDetail();
-    lot.setNumber(LOT1_ID);
+    lot.setNumber(LOT1_NUMBER);
 
-    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_ID))
+    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
         .thenReturn(mockLot);
     when(converter.convertLotToDTO(mockLot)).thenReturn(lot);
-    mockMvc.perform(get(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_ID)).andExpect(status().isOk())
-        .andExpect(jsonPath("$.number", is(LOT1_ID)));
+    mockMvc.perform(get(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_NUMBER)).andExpect(status().isOk())
+        .andExpect(jsonPath("$.number", is(LOT1_NUMBER)));
   }
 
   @Test
   void testGetLotNotFound() throws Exception {
-    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_ID))
+    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
         .thenReturn(null);
-    mockMvc.perform(get(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_ID))
+    mockMvc.perform(get(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
         .andExpect(status().is4xxClientError())
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
         .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
         .andExpect(jsonPath("$.errors[0].detail",
-            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_ID,
+            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_NUMBER,
                 AGREEMENT_NUMBER))))
         .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
   }
 
   @Test
   void testGetLotUnexpectedError() throws Exception {
-    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_ID))
+    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
         .thenThrow(new RuntimeException("Something is amiss"));
-    mockMvc.perform(get(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_ID))
+    mockMvc.perform(get(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
         .andExpect(status().is5xxServerError())
         .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_DEFAULT_DESCRIPTION)));
   }
@@ -114,12 +114,12 @@ class LotControllerTest {
     lotSupplier.setLotContacts(Collections.singleton(contact));
 
     when(
-        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_ID))
+        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
             .thenReturn(lotOrgRoles);
     when(converter.convertLotOrgRolesToLotSupplierDTOs(lotOrgRoles))
         .thenReturn(Collections.singleton(lotSupplier));
 
-    mockMvc.perform(get(GET_LOT_SUPPLIERS_PATH, AGREEMENT_NUMBER, LOT1_ID))
+    mockMvc.perform(get(GET_LOT_SUPPLIERS_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful()).andExpect(jsonPath("$.size()", is(1)))
         .andExpect(jsonPath("$.[0].organization.name", is("ABC Ltd")))
@@ -132,15 +132,15 @@ class LotControllerTest {
   @Test
   void testGetLotSuppliersNotFound() throws Exception {
     when(
-        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_ID))
-            .thenThrow(new LotNotFoundException(LOT1_ID, AGREEMENT_NUMBER));
+        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
+            .thenThrow(new LotNotFoundException(LOT1_NUMBER, AGREEMENT_NUMBER));
 
-    mockMvc.perform(get(GET_LOT_SUPPLIERS_PATH, AGREEMENT_NUMBER, LOT1_ID))
+    mockMvc.perform(get(GET_LOT_SUPPLIERS_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
         .andExpect(status().is4xxClientError())
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
         .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
         .andExpect(jsonPath("$.errors[0].detail",
-            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_ID,
+            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_NUMBER,
                 AGREEMENT_NUMBER))))
         .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
   }
@@ -153,13 +153,13 @@ class LotControllerTest {
     EventType eventType = new EventType();
     eventType.setType("RFI");
 
-    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_ID))
+    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
         .thenReturn(mockLot);
     when(mockLot.getProcurementEventTypes()).thenReturn(lotProcurementEventTypes);
     when(converter.convertLotProcurementEventTypesToDTOs(lotProcurementEventTypes))
         .thenReturn(Collections.singleton(eventType));
 
-    mockMvc.perform(get(GET_LOT_EVENT_TYPES_PATH, AGREEMENT_NUMBER, LOT1_ID))
+    mockMvc.perform(get(GET_LOT_EVENT_TYPES_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().is2xxSuccessful()).andExpect(jsonPath("$.size()", is(1)))
         .andExpect(jsonPath("$.[0].type", is("RFI")));
@@ -167,14 +167,14 @@ class LotControllerTest {
 
   @Test
   void testGetLotEventTypesNotFound() throws Exception {
-    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_ID))
+    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
         .thenReturn(null);
-    mockMvc.perform(get(GET_LOT_EVENT_TYPES_PATH, AGREEMENT_NUMBER, LOT1_ID))
+    mockMvc.perform(get(GET_LOT_EVENT_TYPES_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
         .andExpect(status().is4xxClientError())
         .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
         .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
         .andExpect(jsonPath("$.errors[0].detail",
-            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_ID,
+            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_NUMBER,
                 AGREEMENT_NUMBER))))
         .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
   }

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotControllerTest.java
@@ -1,0 +1,181 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.controller;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.crowncommercial.dts.scale.service.agreements.converter.AgreementConverter;
+import uk.gov.crowncommercial.dts.scale.service.agreements.exception.LotNotFoundException;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.*;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.*;
+import uk.gov.crowncommercial.dts.scale.service.agreements.service.AgreementService;
+
+@WebMvcTest(LotController.class)
+@Import(GlobalErrorHandler.class)
+class LotControllerTest {
+
+  private static final String GET_LOT_PATH = "/agreements/{agreement-id}/lots/{lot-id}";
+  private static final String GET_LOT_SUPPLIERS_PATH =
+      "/agreements/{agreement-id}/lots/{lot-id}/suppliers";
+  private static final String GET_LOT_EVENT_TYPES_PATH =
+      "/agreements/{agreement-id}/lots/{lot-id}/event-types";
+
+  private static final String AGREEMENT_NUMBER = "RM3733";
+  private static final String LOT1_NUMBER = "Lot 1";
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private AgreementService service;
+
+  @MockBean
+  private AgreementConverter converter;
+
+  @MockBean
+  private CommercialAgreement mockCommercialAgreement;
+
+  @MockBean
+  private Lot mockLot;
+
+  @MockBean
+  private CommercialAgreementDocument mockCommercialAgreementDocument;
+
+  @MockBean
+  private CommercialAgreementUpdate mockCommercialAgreementUpdate;
+
+  @MockBean
+  private LotOrganisationRole lotOrganisationRole;
+
+  @MockBean
+  private LotProcurementEventType lotProcurementEventType;
+
+  @Test
+  void testGetLotSuccess() throws Exception {
+    final LotDetail lot = new LotDetail();
+    lot.setNumber(LOT1_NUMBER);
+
+    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
+        .thenReturn(mockLot);
+    when(converter.convertLotToDTO(mockLot)).thenReturn(lot);
+    mockMvc.perform(get(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_NUMBER)).andExpect(status().isOk())
+        .andExpect(jsonPath("$.number", is(LOT1_NUMBER)));
+  }
+
+  @Test
+  void testGetLotNotFound() throws Exception {
+    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
+        .thenReturn(null);
+    mockMvc.perform(get(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
+        .andExpect(status().is4xxClientError())
+        .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
+        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
+        .andExpect(jsonPath("$.errors[0].detail",
+            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_NUMBER,
+                AGREEMENT_NUMBER))))
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
+  }
+
+  @Test
+  void testGetLotUnexpectedError() throws Exception {
+    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
+        .thenThrow(new RuntimeException("Something is amiss"));
+    mockMvc.perform(get(GET_LOT_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
+        .andExpect(status().is5xxServerError())
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_DEFAULT_DESCRIPTION)));
+  }
+
+  @Test
+  void testGetLotSuppliers() throws Exception {
+    final Set<LotOrganisationRole> lotOrgRoles = Collections.singleton(lotOrganisationRole);
+
+    final Organization org = new Organization();
+    org.setName("ABC Ltd");
+    final ContactPoint contactPoint = new ContactPoint();
+    contactPoint.setName("Procurement");
+    final Contact contact = new Contact();
+    contact.setContactId("abc123");
+    contact.setContactPoint(contactPoint);
+    final LotSupplier lotSupplier = new LotSupplier();
+    lotSupplier.setOrganization(org);
+    lotSupplier.setSupplierStatus(SupplierStatus.ACTIVE);
+    lotSupplier.setLotContacts(Collections.singleton(contact));
+
+    when(
+        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
+            .thenReturn(lotOrgRoles);
+    when(converter.convertLotOrgRolesToLotSupplierDTOs(lotOrgRoles))
+        .thenReturn(Collections.singleton(lotSupplier));
+
+    mockMvc.perform(get(GET_LOT_SUPPLIERS_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().is2xxSuccessful()).andExpect(jsonPath("$.size()", is(1)))
+        .andExpect(jsonPath("$.[0].organization.name", is("ABC Ltd")))
+        .andExpect(jsonPath("$.[0].supplierStatus", is("active")))
+        .andExpect(jsonPath("$.[0].lotContacts.size()", is(1)))
+        .andExpect(jsonPath("$.[0].lotContacts.[0].contactId", is("abc123")))
+        .andExpect(jsonPath("$.[0].lotContacts.[0].contact.name", is("Procurement")));
+  }
+
+  @Test
+  void testGetLotSuppliersNotFound() throws Exception {
+    when(
+        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
+            .thenThrow(new LotNotFoundException(LOT1_NUMBER, AGREEMENT_NUMBER));
+
+    mockMvc.perform(get(GET_LOT_SUPPLIERS_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
+        .andExpect(status().is4xxClientError())
+        .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
+        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
+        .andExpect(jsonPath("$.errors[0].detail",
+            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_NUMBER,
+                AGREEMENT_NUMBER))))
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
+  }
+
+  @Test
+  void testGetLotEventTypes() throws Exception {
+    final Set<LotProcurementEventType> lotProcurementEventTypes =
+        Collections.singleton(lotProcurementEventType);
+
+    EventType eventType = new EventType();
+    eventType.setType("RFI");
+
+    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
+        .thenReturn(mockLot);
+    when(mockLot.getProcurementEventTypes()).thenReturn(lotProcurementEventTypes);
+    when(converter.convertLotProcurementEventTypesToDTOs(lotProcurementEventTypes))
+        .thenReturn(Collections.singleton(eventType));
+
+    mockMvc.perform(get(GET_LOT_EVENT_TYPES_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().is2xxSuccessful()).andExpect(jsonPath("$.size()", is(1)))
+        .andExpect(jsonPath("$.[0].type", is("RFI")));
+  }
+
+  @Test
+  void testGetLotEventTypesNotFound() throws Exception {
+    when(service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT1_NUMBER))
+        .thenReturn(null);
+    mockMvc.perform(get(GET_LOT_EVENT_TYPES_PATH, AGREEMENT_NUMBER, LOT1_NUMBER))
+        .andExpect(status().is4xxClientError())
+        .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
+        .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
+        .andExpect(jsonPath("$.errors[0].detail",
+            is(String.format(LotNotFoundException.ERROR_MSG_TEMPLATE, LOT1_NUMBER,
+                AGREEMENT_NUMBER))))
+        .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
+  }
+}

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/converter/AgreementConverterTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/converter/AgreementConverterTest.java
@@ -28,7 +28,8 @@ import uk.gov.crowncommercial.dts.scale.service.agreements.service.AgreementServ
     SectorConverter.class, AgreementUpdateConverter.class, RouteToMarketConverter.class,
     AgreementContactsConverter.class, LotSupplierPropertyMap.class, LotSupplierOrgConverter.class,
     LotContactsConverter.class, SupplierStatusConverter.class, TimestampConverter.class,
-    AgreementOwnerConverter.class, AgreementBenefitConverter.class, ConverterUtils.class})
+    AgreementOwnerConverter.class, AgreementBenefitConverter.class, ConverterUtils.class,
+    EventTypeConverter.class})
 @ActiveProfiles("test")
 class AgreementConverterTest {
 


### PR DESCRIPTION
Added the `/agreements/{agreement-id}/lots/{lot-id}/event-types` endpoint.

Split out Agreements/Lots into 2 controllers, as the existing one and test class was starting grow and we have more endpoints lined up to implement after this (DataTemplate and DocumentTemplate to come).

Also renamed the `caNumber` params to match the current API spec `agreement-id` name.