### PR TITLE
Feature/scat 1777 procurement templates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<modelmapper.version>2.3.5</modelmapper.version>
+		<hibernate-types.version>2.12.1</hibernate-types.version>
 	</properties>
 
 	<dependencies>
@@ -53,7 +54,6 @@
 			<optional>true</optional>
 		</dependency>
 
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
@@ -65,6 +65,12 @@
 			<groupId>org.modelmapper</groupId>
 			<artifactId>modelmapper</artifactId>
 			<version>${modelmapper.version}</version>
+		</dependency>
+		
+		<dependency>
+		    <groupId>com.vladmihalcea</groupId>
+		    <artifactId>hibernate-types-52</artifactId>
+		    <version>${hibernate-types.version}</version>
 		</dependency>
 
 		<!-- Test dependencies -->

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/config/PostgreSQL10JsonDialect.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/config/PostgreSQL10JsonDialect.java
@@ -1,0 +1,21 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.config;
+
+import java.sql.Types;
+import org.hibernate.dialect.PostgreSQL10Dialect;
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+
+/**
+ * This class gets around the error `javax.persistence.PersistenceException:
+ * org.hibernate.MappingException: No Dialect mapping for JDBC type: 1111` caused by the custom
+ * JSONB TypeDef in {@link ProcurementQuestionTemplate}
+ * 
+ * See: https://vladmihalcea.com/hibernate-no-dialect-mapping-for-jdbc-type/
+ *
+ */
+public class PostgreSQL10JsonDialect extends PostgreSQL10Dialect {
+
+  public PostgreSQL10JsonDialect() {
+    super();
+    this.registerHibernateType(Types.OTHER, JsonBinaryType.class.getName());
+  }
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/AgreementController.java
@@ -36,18 +36,19 @@ public class AgreementController {
 
   @GetMapping("/{agreement-id}")
   public AgreementDetail getAgreementDetail(
-      @PathVariable(value = "agreement-id") final String agreementId) {
-    log.debug("getAgreement: {}", agreementId);
-    final CommercialAgreement ca = getAgreement(agreementId);
+      @PathVariable(value = "agreement-id") final String agreementNumber) {
+    log.debug("getAgreement: {}", agreementNumber);
+    final CommercialAgreement ca = getAgreement(agreementNumber);
     return converter.convertAgreementToDTO(ca);
   }
 
   @GetMapping("/{agreement-id}/lots")
   public Collection<LotDetail> getAgreementLots(
-      @PathVariable(value = "agreement-id") final String agreementId,
+      @PathVariable(value = "agreement-id") final String agreementNumber,
       @RequestParam Optional<BuyingMethod> buyingMethod) {
-    log.debug("getAgreementLots: agreementId={}, buyingMethod={}", agreementId, buyingMethod);
-    final CommercialAgreement ca = getAgreement(agreementId);
+    log.debug("getAgreementLots: agreementNumber={}, buyingMethod={}", agreementNumber,
+        buyingMethod);
+    final CommercialAgreement ca = getAgreement(agreementNumber);
     Collection<LotDetail> lots = converter.convertLotsToDTOs(ca.getLots());
     if (buyingMethod.isPresent()) {
       return filterLotsByBuyingMethod(lots, buyingMethod.get());
@@ -58,24 +59,24 @@ public class AgreementController {
 
   @GetMapping("/{agreement-id}/documents")
   public Collection<Document> getAgreementDocuments(
-      @PathVariable(value = "agreement-id") final String agreementId) {
-    log.debug("getAgreementDocuments: {}", agreementId);
-    final CommercialAgreement ca = getAgreement(agreementId);
+      @PathVariable(value = "agreement-id") final String agreementNumber) {
+    log.debug("getAgreementDocuments: {}", agreementNumber);
+    final CommercialAgreement ca = getAgreement(agreementNumber);
     return converter.convertAgreementDocumentsToDTOs(ca.getDocuments());
   }
 
   @GetMapping("/{agreement-id}/updates")
   public Collection<AgreementUpdate> getAgreementUpdates(
-      @PathVariable(value = "agreement-id") final String agreementId) {
-    log.debug("getAgreementUpdates: {}", agreementId);
-    final CommercialAgreement ca = getAgreement(agreementId);
+      @PathVariable(value = "agreement-id") final String agreementNumber) {
+    log.debug("getAgreementUpdates: {}", agreementNumber);
+    final CommercialAgreement ca = getAgreement(agreementNumber);
     return converter.convertAgreementUpdatesToDTOs(ca.getUpdates());
   }
 
-  private CommercialAgreement getAgreement(final String caNumber) {
-    final CommercialAgreement ca = service.findAgreementByNumber(caNumber);
+  private CommercialAgreement getAgreement(final String agreementNumber) {
+    final CommercialAgreement ca = service.findAgreementByNumber(agreementNumber);
     if (ca == null) {
-      throw new AgreementNotFoundException(caNumber);
+      throw new AgreementNotFoundException(agreementNumber);
     }
     return ca;
   }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotController.java
@@ -75,7 +75,8 @@ public class LotController {
       @PathVariable(value = "lot-id") final String lotNumber,
       @PathVariable(value = "event-type") final String eventType) {
 
-    log.debug("getDataTemplates: agreementNumber={}, lotNumber={}", agreementNumber, lotNumber);
+    log.debug("getDataTemplates: agreementNumber={}, lotNumber={}, eventType={}", agreementNumber,
+        lotNumber, eventType);
 
     final Collection<LotProcurementQuestionTemplate> questions =
         service.findLotProcurementQuestionTemplates(agreementNumber, lotNumber, eventType);

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotController.java
@@ -14,6 +14,7 @@ import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.LotDetail;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.LotSupplier;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.Lot;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.LotOrganisationRole;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.LotProcurementQuestionTemplate;
 import uk.gov.crowncommercial.dts.scale.service.agreements.service.AgreementService;
 
 /**
@@ -30,42 +31,56 @@ public class LotController {
   private final AgreementConverter converter;
 
   @GetMapping
-  public LotDetail getLot(@PathVariable(value = "agreement-id") final String agreementId,
-      @PathVariable(value = "lot-id") final String lotId) {
-    log.debug("getLot: agreementId={},lotId={}", agreementId, lotId);
-    final Lot lot = service.findLotByAgreementNumberAndLotNumber(agreementId, lotId);
+  public LotDetail getLot(@PathVariable(value = "agreement-id") final String agreementNumber,
+      @PathVariable(value = "lot-id") final String lotNumber) {
+    log.debug("getLot: agreementNumber={}, lotNumber={}", agreementNumber, lotNumber);
+    final Lot lot = service.findLotByAgreementNumberAndLotNumber(agreementNumber, lotNumber);
     if (lot == null) {
-      throw new LotNotFoundException(lotId, agreementId);
+      throw new LotNotFoundException(lotNumber, agreementNumber);
     }
     return converter.convertLotToDTO(lot);
   }
 
   @GetMapping("/suppliers")
   public Collection<LotSupplier> getLotSuppliers(
-      @PathVariable(value = "agreement-id") final String agreementId,
-      @PathVariable(value = "lot-id") final String lotId) {
+      @PathVariable(value = "agreement-id") final String agreementNumber,
+      @PathVariable(value = "lot-id") final String lotNumber) {
 
-    log.debug("getLotSuppliers: agreementId={}, lotId={}", agreementId, lotId);
+    log.debug("getLotSuppliers: agreementNumber={}, lotNumber={}", agreementNumber, lotNumber);
 
     final Collection<LotOrganisationRole> lotOrgRoles =
-        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(agreementId, lotId);
+        service.findLotSupplierOrgRolesByAgreementNumberAndLotNumber(agreementNumber, lotNumber);
 
     return converter.convertLotOrgRolesToLotSupplierDTOs(lotOrgRoles);
   }
 
   @GetMapping("/event-types")
   public Collection<EventType> getLotEventTypes(
-      @PathVariable(value = "agreement-id") final String agreementId,
-      @PathVariable(value = "lot-id") final String lotId) {
+      @PathVariable(value = "agreement-id") final String agreementNumber,
+      @PathVariable(value = "lot-id") final String lotNumber) {
 
-    log.debug("getLotEventTypes: agreementId={}, lotId={}", agreementId, lotId);
+    log.debug("getLotEventTypes: agreementNumber={}, lotNumber={}", agreementNumber, lotNumber);
 
-    final Lot lot = service.findLotByAgreementNumberAndLotNumber(agreementId, lotId);
+    final Lot lot = service.findLotByAgreementNumberAndLotNumber(agreementNumber, lotNumber);
     if (lot == null) {
-      throw new LotNotFoundException(lotId, agreementId);
+      throw new LotNotFoundException(lotNumber, agreementNumber);
     }
 
     return converter.convertLotProcurementEventTypesToDTOs(lot.getProcurementEventTypes());
+  }
+
+  @GetMapping("/event-types/{event-type}/data-templates")
+  public Collection<Object> getDataTemplates(
+      @PathVariable(value = "agreement-id") final String agreementNumber,
+      @PathVariable(value = "lot-id") final String lotNumber,
+      @PathVariable(value = "event-type") final String eventType) {
+
+    log.debug("getDataTemplates: agreementNumber={}, lotNumber={}", agreementNumber, lotNumber);
+
+    final Collection<LotProcurementQuestionTemplate> questions =
+        service.findLotProcurementQuestionTemplates(agreementNumber, lotNumber, eventType);
+
+    return converter.convertLotProcurementQuestionTemplateToString(questions);
   }
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/converter/AgreementConverter.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/converter/AgreementConverter.java
@@ -99,4 +99,13 @@ public class AgreementConverter {
     return lotProcurementEventTypes.stream().map(lpet -> modelMapper.map(lpet, EventType.class))
         .collect(Collectors.toSet());
   }
+
+  public Collection<Object> convertLotProcurementQuestionTemplateToString(
+      final Collection<LotProcurementQuestionTemplate> lotProcurementQuestionTemplates) {
+
+    return lotProcurementQuestionTemplates.stream()
+        .map(t -> t.getProcurementQuestionTemplate().getTemplatePayload())
+        .collect(Collectors.toSet());
+
+  }
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/converter/AgreementConverter.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/converter/AgreementConverter.java
@@ -102,7 +102,6 @@ public class AgreementConverter {
 
   public Collection<Object> convertLotProcurementQuestionTemplateToString(
       final Collection<LotProcurementQuestionTemplate> lotProcurementQuestionTemplates) {
-
     return lotProcurementQuestionTemplates.stream()
         .map(t -> t.getProcurementQuestionTemplate().getTemplatePayload())
         .collect(Collectors.toSet());

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/LotProcurementQuestionTemplate.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/LotProcurementQuestionTemplate.java
@@ -1,0 +1,36 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.model.entity;
+
+import javax.persistence.*;
+import org.hibernate.annotations.Immutable;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * Lot Procurement Question Template.
+ */
+@Entity
+@Immutable
+@Table(name = "lot_procurement_question_templates")
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class LotProcurementQuestionTemplate {
+
+  @EmbeddedId
+  LotProcurementQuestionTemplateKey key;
+
+  @MapsId("lotId")
+  @ManyToOne
+  @JoinColumn(name = "lot_id")
+  Lot lot;
+
+  @MapsId("templateId")
+  @ManyToOne
+  @JoinColumn(name = "template_id")
+  ProcurementQuestionTemplate procurementQuestionTemplate;
+
+  @MapsId("procurementEventId")
+  @ManyToOne
+  @JoinColumn(name = "procurement_event_type_id")
+  ProcurementEventType procurementEventType;
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/LotProcurementQuestionTemplateKey.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/LotProcurementQuestionTemplateKey.java
@@ -1,0 +1,25 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.model.entity;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import lombok.Data;
+
+/**
+ * Compound Key.
+ */
+@Data
+@Embeddable
+public class LotProcurementQuestionTemplateKey implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @Column(name = "lot_id")
+  Integer lotId;
+
+  @Column(name = "template_id")
+  Integer templateId;
+
+  @Column(name = "procurement_event_type_id")
+  Integer procurementEventTypeId;
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/ProcurementQuestionTemplate.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/ProcurementQuestionTemplate.java
@@ -1,0 +1,39 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.model.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import org.hibernate.annotations.Immutable;
+import org.hibernate.annotations.Type;
+import org.hibernate.annotations.TypeDef;
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * Procurement Question Template.
+ */
+@Entity
+@Immutable
+@Table(name = "procurement_question_templates")
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@TypeDef(name = "jsonb", typeClass = JsonBinaryType.class)
+public class ProcurementQuestionTemplate {
+
+  @Id
+  @Column(name = "template_id")
+  Integer id;
+
+  @Column(name = "template_name")
+  String templateName;
+
+  @Column(name = "template_url")
+  String templateUrl;
+
+  @Type(type = "jsonb")
+  @Column(name = "template_payload")
+  Object templatePayload;
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/LotProcurementQuestionTemplateRepo.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/LotProcurementQuestionTemplateRepo.java
@@ -1,0 +1,17 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.repository;
+
+import java.util.Collection;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.LotProcurementQuestionTemplate;
+
+/**
+ * Commercial Agreement Data Repository.
+ */
+@Repository
+public interface LotProcurementQuestionTemplateRepo
+    extends JpaRepository<LotProcurementQuestionTemplate, Integer> {
+
+  Collection<LotProcurementQuestionTemplate> findByLotAgreementNumberAndLotNumberAndProcurementEventTypeName(
+      String agreementNumber, String lotNumber, String eventType);
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/AgreementService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/AgreementService.java
@@ -10,7 +10,9 @@ import uk.gov.crowncommercial.dts.scale.service.agreements.exception.LotNotFound
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.CommercialAgreement;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.Lot;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.LotOrganisationRole;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.LotProcurementQuestionTemplate;
 import uk.gov.crowncommercial.dts.scale.service.agreements.repository.CommercialAgreementRepo;
+import uk.gov.crowncommercial.dts.scale.service.agreements.repository.LotProcurementQuestionTemplateRepo;
 import uk.gov.crowncommercial.dts.scale.service.agreements.repository.LotRepo;
 
 /**
@@ -24,6 +26,7 @@ public class AgreementService {
 
   private final CommercialAgreementRepo commercialAgreementRepo;
   private final LotRepo lotRepo;
+  private final LotProcurementQuestionTemplateRepo questionTemplateRepo;
 
   /**
    * Get all agreements.
@@ -53,10 +56,11 @@ public class AgreementService {
    * @param lotNumber Lot number
    * @return Lot
    */
-  public Lot findLotByAgreementNumberAndLotNumber(final String caNumber, final String lotNumber) {
-    log.debug("findLotByAgreementNumberAndLotNumber: caNumber={},lotNumber={}", caNumber,
-        lotNumber);
-    return lotRepo.findByAgreementNumberAndNumber(caNumber, lotNumber);
+  public Lot findLotByAgreementNumberAndLotNumber(final String agreementNumber,
+      final String lotNumber) {
+    log.debug("findLotByAgreementNumberAndLotNumber: agreementNumber={},lotNumber={}",
+        agreementNumber, lotNumber);
+    return lotRepo.findByAgreementNumberAndNumber(agreementNumber, lotNumber);
   }
 
   /**
@@ -79,17 +83,32 @@ public class AgreementService {
    * @throws LotNotFoundException if CA or lot not found
    */
   public Collection<LotOrganisationRole> findLotSupplierOrgRolesByAgreementNumberAndLotNumber(
-      final String caNumber, final String lotNumber) {
+      final String agreementNumber, final String lotNumber) {
 
-    final Lot lot = lotRepo.findByAgreementNumberAndNumber(caNumber, lotNumber);
+    final Lot lot = lotRepo.findByAgreementNumberAndNumber(agreementNumber, lotNumber);
     if (lot == null) {
-      throw new LotNotFoundException(lotNumber, caNumber);
+      throw new LotNotFoundException(lotNumber, agreementNumber);
     }
 
     // Filter the lot organisation roles for role-type 'supplier'
     return lot.getOrganisationRoles().stream()
         .filter(lor -> "supplier".equalsIgnoreCase(lor.getRoleType().getName()))
         .collect(Collectors.toSet());
+  }
+
+  /**
+   * Find ProcurementQuestionTemplates
+   * 
+   * @param caNumber Commercial Agreement number
+   * @param lotNumber Lot number
+   * @param eventType Event type (e.g. RFI)
+   * @return
+   */
+  public Collection<LotProcurementQuestionTemplate> findLotProcurementQuestionTemplates(
+      final String agreementNumber, final String lotNumber, final String eventType) {
+
+    return questionTemplateRepo.findByLotAgreementNumberAndLotNumberAndProcurementEventTypeName(
+        agreementNumber, lotNumber, eventType);
   }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,9 @@ spring:
     show-sql: false
     hibernate:
       ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: uk.gov.crowncommercial.dts.scale.service.agreements.config.PostgreSQL10JsonDialect
     
 ---
 spring:

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/converter/AgreementConverterTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/converter/AgreementConverterTest.java
@@ -117,6 +117,8 @@ class AgreementConverterTest {
   private static final String BENEFIT_ONE = "Benefit 1";
   private static final String BENEFIT_TWO = "Benefit 2";
 
+  // Procurement Question Templates
+  private static final String CRITERION_PAYLOAD_ONE = "[[{\"id\\\": \\\"Criterion 1\\\"}]]";
 
   @Autowired
   AgreementConverter converter;
@@ -251,6 +253,19 @@ class AgreementConverterTest {
     LotSupplier lotSupplier2 = getLotSupplier(2, 3, 3);
 
     assertThat(lotSuppliers, hasItems(lotSupplier1, lotSupplier2));
+  }
+
+  @Test
+  void testDataTemplates() {
+    ProcurementQuestionTemplate template = new ProcurementQuestionTemplate();
+    template.setTemplatePayload(CRITERION_PAYLOAD_ONE);
+    LotProcurementQuestionTemplate lotTemplate = new LotProcurementQuestionTemplate();
+    lotTemplate.setProcurementQuestionTemplate(template);
+    Collection<Object> criterionPayloads =
+        converter.convertLotProcurementQuestionTemplateToString(Collections.singleton(lotTemplate));
+
+    assertEquals(1, criterionPayloads.size());
+    assertEquals(CRITERION_PAYLOAD_ONE, criterionPayloads.stream().findFirst().get());
   }
 
   private LotSupplier getLotSupplier(int instance, int minContactPoint, int maxContactPoint) {

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/AgreementServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/AgreementServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.crowncommercial.dts.scale.service.agreements.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
+import java.util.Collection;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,15 +11,18 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.CommercialAgreement;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.Lot;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.LotProcurementQuestionTemplate;
 import uk.gov.crowncommercial.dts.scale.service.agreements.repository.CommercialAgreementRepo;
+import uk.gov.crowncommercial.dts.scale.service.agreements.repository.LotProcurementQuestionTemplateRepo;
 import uk.gov.crowncommercial.dts.scale.service.agreements.repository.LotRepo;
 
 @SpringBootTest
 @ActiveProfiles("test")
-public class AgreementServiceTest {
+class AgreementServiceTest {
 
   private static final String AGREEMENT_NUMBER = "RM1000";
   private static final String LOT_NUMBER = "Lot 1";
+  private static final String EVENT_TYPE = "RFI";
 
   @MockBean
   private CommercialAgreementRepo mockCommercialAgreementRepo;
@@ -33,29 +37,44 @@ public class AgreementServiceTest {
   private LotRepo mockLotRepo;
 
   @MockBean
+  private LotProcurementQuestionTemplateRepo mockLotProcurementQuestionTemplateRepo;
+
+  @MockBean
   private Lot mockLot;
+
+  @MockBean
+  private Collection<LotProcurementQuestionTemplate> mockTemplates;
 
   @Autowired
   AgreementService service;
 
   @Test
-  public void testGetAgreement() throws Exception {
+  void testGetAgreement() throws Exception {
     when(mockCommercialAgreementRepo.findByNumber(AGREEMENT_NUMBER))
         .thenReturn(mockCommercialAgreement);
     assertEquals(mockCommercialAgreement, service.findAgreementByNumber(AGREEMENT_NUMBER));
   }
 
   @Test
-  public void testGetAgreements() throws Exception {
+  void testGetAgreements() throws Exception {
     when(mockCommercialAgreementRepo.findAll()).thenReturn(mockCommercialAgreements);
     assertEquals(mockCommercialAgreements, service.getAgreements());
   }
 
   @Test
-  public void testGetLot() throws Exception {
+  void testGetLot() throws Exception {
     when(mockLotRepo.findByAgreementNumberAndNumber(AGREEMENT_NUMBER, LOT_NUMBER))
         .thenReturn(mockLot);
     assertEquals(mockLot,
         service.findLotByAgreementNumberAndLotNumber(AGREEMENT_NUMBER, LOT_NUMBER));
+  }
+
+  @Test
+  void testFindLotProcurementQuestionTemplates() throws Exception {
+    when(mockLotProcurementQuestionTemplateRepo
+        .findByLotAgreementNumberAndLotNumberAndProcurementEventTypeName(AGREEMENT_NUMBER,
+            LOT_NUMBER, EVENT_TYPE)).thenReturn(mockTemplates);
+    assertEquals(mockTemplates,
+        service.findLotProcurementQuestionTemplates(AGREEMENT_NUMBER, LOT_NUMBER, EVENT_TYPE));
   }
 }


### PR DESCRIPTION
Added endpoint for `/agreements/{agreement-id}/lots/{lot-id}/event-types/{event-type}/data-templates`

Had to introduce a new library `hibernate-types-52` to work with JSONB (and override the Postgres dialect). There may be a better was to do this but most of the info I could find online pointed at use of this library.