### PR TITLE
Bugfix - set Java version to 11

### DIFF
--- a/iac/modules/agreements-service/main.tf
+++ b/iac/modules/agreements-service/main.tf
@@ -32,7 +32,7 @@ resource "cloudfoundry_app" "agreements_service" {
   disk_quota  = var.disk_quota
   enable_ssh  = true
   environment = {
-    #ENV_VAR: var.variable_name
+    JBP_CONFIG_OPEN_JDK_JRE : "{ \"jre\": { version: 11.+ } }"
   }
   health_check_timeout = var.healthcheck_timeout
   health_check_type    = "port"


### PR DESCRIPTION
Hoping this resolved the Travis error - `java.lang.UnsupportedClassVersionError: uk/gov/crowncommercial/dts/scale/service/agreements/Application has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0`