### PR TITLE
Revert "Wrong Docker Image - Try the one Snyk recommends"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:17-al2023-jdk
+FROM amazoncorretto:17
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
Reverts Crown-Commercial-Service/ccs-scale-agreements-service#171

We think this may have caused an error we're seeing in ECR