### PR TITLE
Add Supplier Count to LotDetail

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -20,11 +20,11 @@ checks:
   method-count:
     enabled: true
     config:
-    threshold: 20
+      threshold: 20
   method-lines:
     enabled: true
     config:
-    threshold: 70
+      threshold: 70
   nested-control-flow:
     enabled: true
     config:
@@ -36,4 +36,4 @@ checks:
   similar-code:
     enabled: true
     config:
-  threshold: 60
+      threshold: 60

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/LotDetail.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/LotDetail.java
@@ -66,4 +66,8 @@ public class LotDetail implements Serializable {
    */
   private Collection<LotRuleDTO> rules;
 
+  /**
+   * Count of suppliers attached to the lot
+   */
+  private Integer supplierCount;
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/Lot.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/Lot.java
@@ -99,4 +99,7 @@ public class Lot {
   @OneToMany(fetch = FetchType.LAZY)
   @JoinColumn(name ="lot_id")
   Set<TemplateGroup> templateGroups;
+
+  @Formula("(SELECT COUNT(*) FROM lot_organisation_roles r WHERE r.lot_id = lot_id and r.role_type_id = '2' and r.organisation_status = 'A')")
+  Integer supplierCount;
 }


### PR DESCRIPTION
LotDetail should include a supplier count, so that consuming applications only need to call GetLotSuppliers if they need supplier info