### PR TITLE
Lot supplier PUT endpoint

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/BLL/BusinessLogicClient.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/BLL/BusinessLogicClient.java
@@ -5,15 +5,9 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.*;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.*;
-import uk.gov.crowncommercial.dts.scale.service.agreements.service.AgreementService;
-import uk.gov.crowncommercial.dts.scale.service.agreements.service.MappingService;
-import uk.gov.crowncommercial.dts.scale.service.agreements.service.QuestionTemplateService;
-import uk.gov.crowncommercial.dts.scale.service.agreements.service.WordpressService;
+import uk.gov.crowncommercial.dts.scale.service.agreements.service.*;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -24,6 +18,9 @@ import java.util.stream.Collectors;
 public class BusinessLogicClient {
     @Autowired
     private AgreementService agreementService;
+
+    @Autowired
+    private SupplierService supplierService;
 
     @Autowired
     private WordpressService wordpressService;
@@ -291,5 +288,24 @@ public class BusinessLogicClient {
         });
 
         return lotCollection.stream().map(lot -> { return mappingService.mapLotToLotDetail(agreementService.createOrUpdateLot(lot));}).collect(Collectors.toSet());
+    }
+
+    /**
+     * batch create or update a list of LotSupplier objects that was given and return it
+     */
+    public Collection<LotSupplier> saveLotSuppliers(String agreementId, String lotId,  Set<LotSupplier> lotSuppliersSet) {
+        Lot lot = agreementService.findLotByAgreementNumberAndLotNumber(agreementId, lotId);
+
+        lotSuppliersSet.forEach(lotDetail ->{
+            final Organisation organisation = mappingService.mapLotSupplierToOrganisation(lotDetail);
+            organisation.isValid();
+
+            ContactDetail contactDetail = mappingService.mapLotSupplierToContactDetail(lotDetail);
+            contactDetail = contactDetail.isValid() ? contactDetail : null;
+
+            supplierService.addSupplierRelationship(lot, organisation, contactDetail, lotDetail.getLastUpdatedBy(), lotDetail.getSupplierStatus());
+        });
+
+        return getLotSuppliers(agreementId, lotId);
     }
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/BLL/BusinessLogicClient.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/BLL/BusinessLogicClient.java
@@ -293,8 +293,8 @@ public class BusinessLogicClient {
     /**
      * batch create or update a list of LotSupplier objects that was given and return it
      */
-    public Collection<LotSupplier> saveLotSuppliers(String agreementId, String lotId,  Set<LotSupplier> lotSuppliersSet) {
-        Lot lot = agreementService.findLotByAgreementNumberAndLotNumber(agreementId, lotId);
+    public Collection<LotSupplier> saveLotSuppliers(String agreementId, String lotNumber,  Set<LotSupplier> lotSuppliersSet) {
+        Lot lot = agreementService.findLotByAgreementNumberAndLotNumber(agreementId, lotNumber);
 
         lotSuppliersSet.forEach(lotDetail ->{
             final Organisation organisation = mappingService.mapLotSupplierToOrganisation(lotDetail);
@@ -306,6 +306,6 @@ public class BusinessLogicClient {
             supplierService.addSupplierRelationship(lot, organisation, contactDetail, lotDetail.getLastUpdatedBy(), lotDetail.getSupplierStatus());
         });
 
-        return getLotSuppliers(agreementId, lotId);
+        return getLotSuppliers(agreementId, lotNumber);
     }
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/GlobalErrorHandler.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/GlobalErrorHandler.java
@@ -37,7 +37,7 @@ public class GlobalErrorHandler implements ErrorController {
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler({ValidationException.class, HttpMessageNotReadableException.class,
-      MethodArgumentTypeMismatchException.class, InvalidAgreementException.class, InvalidLotException.class})
+      MethodArgumentTypeMismatchException.class, InvalidAgreementException.class, InvalidLotException.class, InvalidSchemeExpection.class, InvalidOrganisationException.class, InvalidContactDetailExpection.class})
   public ApiErrors handleValidationException(final Exception exception) {
 
     rollbar.warning(exception, "Request validation exception");
@@ -54,7 +54,7 @@ public class GlobalErrorHandler implements ErrorController {
   }
 
   @ResponseStatus(HttpStatus.NOT_FOUND)
-  @ExceptionHandler({AgreementNotFoundException.class, LotNotFoundException.class})
+  @ExceptionHandler({AgreementNotFoundException.class, LotNotFoundException.class, OrganisationNotFoundException.class})
   public ApiErrors handleResourceNotFoundException(final Exception exception) {
 
     rollbar.warning(exception, "Resource not found exception");

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/LotController.java
@@ -8,6 +8,7 @@ import uk.gov.crowncommercial.dts.scale.service.agreements.BLL.BusinessLogicClie
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.*;
 
 import java.util.Collection;
+import java.util.Set;
 
 /**
  * Lot Controller
@@ -71,4 +72,12 @@ public class LotController {
 
     return businessLogicClient.saveLot(lotDetail, agreementNumber, lotNumber);
   }
+
+  @PutMapping("/suppliers")
+  public Collection<LotSupplier> updateLotSuppliers(@PathVariable(value = "agreement-id") final String agreementNumber, @PathVariable(value = "lot-id") final String lotNumber, @RequestBody final Set<LotSupplier> lotSuppliersSet) {
+    log.debug("updateLotSuppliers called with values: agreementNumber={}, lotNumber={}", agreementNumber, lotNumber);
+
+    return businessLogicClient.saveLotSuppliers(agreementNumber, lotNumber, lotSuppliersSet);
+  }
+
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/exception/InvalidContactDetailExpection.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/exception/InvalidContactDetailExpection.java
@@ -1,0 +1,11 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.exception;
+
+public class InvalidContactDetailExpection  extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+    public static final String ERROR_MSG_TEMPLATE = "Invalid contact detail format, missing '%s'";
+
+    public InvalidContactDetailExpection(final String missingField) {
+        super(String.format(ERROR_MSG_TEMPLATE, missingField));
+    }
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/exception/InvalidOrganisationException.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/exception/InvalidOrganisationException.java
@@ -1,0 +1,10 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.exception;
+
+public class InvalidOrganisationException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+    public static final String ERROR_MSG_TEMPLATE = "Invalid organisation format, missing '%s'";
+
+    public InvalidOrganisationException(final String missingField) {
+        super(String.format(ERROR_MSG_TEMPLATE, missingField));
+    }
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/exception/InvalidSchemeExpection.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/exception/InvalidSchemeExpection.java
@@ -1,0 +1,11 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.exception;
+
+public class InvalidSchemeExpection extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+    public static final String ERROR_MSG_TEMPLATE = "Invalid scheme '%s' passed in";
+
+    public InvalidSchemeExpection(final String scheme) {super(String.format(ERROR_MSG_TEMPLATE, scheme));}
+
+    public InvalidSchemeExpection() {super("Invalid scheme passed in");}
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/exception/OrganisationNotFoundException.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/exception/OrganisationNotFoundException.java
@@ -1,0 +1,11 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.exception;
+
+public class OrganisationNotFoundException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+    public static final String ERROR_MSG_TEMPLATE = "Organisation with legal name of '%s' not found";
+
+    public OrganisationNotFoundException(final String legalName) {
+        super(String.format(ERROR_MSG_TEMPLATE, legalName));
+    }
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/mapping/LotSupplierMapper.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/mapping/LotSupplierMapper.java
@@ -4,6 +4,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
+import uk.gov.crowncommercial.dts.scale.service.agreements.exception.InvalidSchemeExpection;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.*;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.ContactDetail;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.ContactPointLotOrgRole;
@@ -32,6 +33,36 @@ public abstract class LotSupplierMapper {
     @Mapping(source = "isActive", target = "active")
     public abstract OrganizationDetail organisationToOrganizationDetail(Organisation orgModel);
 
+
+
+    @Mapping(source = "organization.address.streetAddress", target = "streetAddress")
+    @Mapping(source = "organization.address.locality", target = "locality")
+    @Mapping(source = "organization.address.region", target = "region")
+    @Mapping(source = "organization.address.postalCode", target = "postalCode")
+    @Mapping(source = "organization.address.countryName", target = "countryName")
+    @Mapping(source = "organization.address.countryCode", target = "countryCode")
+    @Mapping(source = "organization.address.uprn", target = "uprn")
+    @Mapping(source = "organization.contactPoint.name", target = "name")
+    @Mapping(source = "organization.contactPoint.email", target = "emailAddress")
+    @Mapping(source = "organization.contactPoint.telephone", target = "telephoneNumber")
+    @Mapping(source = "organization.contactPoint.faxNumber", target = "faxNumber")
+    @Mapping(source = "organization.contactPoint.url", target = "url")
+    public abstract ContactDetail lotSupplierToContactDetail(LotSupplier orgModel);
+
+
+    @Mapping(source = "organization.identifier.legalName", target = "legalName")
+    @Mapping(source = "organization.identifier.scheme", target = "registryCode", qualifiedByName = "schemeToRegistryCode")
+    @Mapping(source = "organization.identifier.id", target = "entityId")
+    @Mapping(source = "organization.identifier.uri", target = "uri")
+    @Mapping(source = "supplierStatus", target = "status")
+    @Mapping(source = "organization.details.creationDate", target = "incorporationDate")
+    @Mapping(source = "organization.details.countryCode", target = "incorporationCountry")
+    @Mapping(source = "organization.address.countryName", target = "countryName")
+    @Mapping(source = "organization.details.isSme", target = "isSme")
+    @Mapping(source = "organization.details.isVcse", target = "isVcse")
+    @Mapping(source = "organization.details.active", target = "isActive")
+    public abstract Organisation lotSupplierToOrganisation(LotSupplier orgModel);
+
     @Named("registryCodeToOrgScheme")
     public static Scheme registryCodeToOrgScheme(String registryCode) {
         if (registryCode != null && !registryCode.isEmpty()) {
@@ -43,6 +74,17 @@ public abstract class LotSupplierMapper {
         }
 
         return null;
+    }
+
+    @Named("schemeToRegistryCode")
+    public static String schemeToRegistryCodeString(Scheme scheme) {
+
+        if (scheme != null){
+            return scheme.getName();
+        }else{
+            throw new InvalidSchemeExpection();
+        }
+
     }
 
     @Mapping(target="id", source="orgModel.entityId")

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/Address.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/Address.java
@@ -40,4 +40,8 @@ public class Address implements Serializable {
    */
   private String countryCode;
 
+  /**
+   * Unique Property Reference Number
+   */
+  private String uprn;
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/LotSupplier.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/LotSupplier.java
@@ -15,4 +15,6 @@ public class LotSupplier implements Serializable {
   private SupplierStatus supplierStatus;
 
   private Set<Contact> lotContacts;
+
+  private String lastUpdatedBy;
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/OrganizationDetail.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/OrganizationDetail.java
@@ -34,6 +34,9 @@ public class OrganizationDetail implements Serializable {
    */
   private String companyType;
 
+  @JsonProperty("is_sme")
+  private Boolean isSme;
+
   /**
    * Is company voluntary, community and social enterprise
    */

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/SupplierStatus.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/SupplierStatus.java
@@ -39,4 +39,12 @@ public enum SupplierStatus {
     return null;
   }
 
+  public static char getChar(SupplierStatus ss) {
+    switch(ss) {
+      case SUSPENDED: return 'S';
+      case EXCLUDED:  return 'E';
+      default:        return 'A';
+    }
+  }
+
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/ContactDetail.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/ContactDetail.java
@@ -1,13 +1,9 @@
 package uk.gov.crowncommercial.dts.scale.service.agreements.model.entity;
 
 import java.time.LocalDate;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Immutable;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.experimental.FieldDefaults;
@@ -16,7 +12,6 @@ import lombok.experimental.FieldDefaults;
  *
  */
 @Entity
-@Immutable
 @Table(name = "contact_details")
 @Data
 @FieldDefaults(level = AccessLevel.PRIVATE)
@@ -24,11 +19,15 @@ import lombok.experimental.FieldDefaults;
 public class ContactDetail {
 
   @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "contact_detail_id")
   Integer id;
 
+  @Transient
+  String name;
+
   @Column(name = "effective_from")
-  LocalDate effectiveFrom;
+  LocalDate effectiveFrom = LocalDate.now();
 
   @Column(name = "effective_to")
   LocalDate effectiveTo;
@@ -65,4 +64,17 @@ public class ContactDetail {
 
   @Column(name = "url")
   String url;
+
+  public Boolean isValid(){
+    if (streetAddress == null || streetAddress.isEmpty()) {
+      if (postalCode == null || postalCode.isEmpty()){
+        if (countryCode == null || countryCode.isEmpty()) {
+          if (countryName == null || countryName.isEmpty()) {
+            return Boolean.FALSE;
+          }
+        }
+      }
+    }
+    return Boolean.TRUE;
+  }
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/ContactPointLotOrgRole.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/ContactPointLotOrgRole.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import javax.persistence.*;
 
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Immutable;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.experimental.FieldDefaults;
@@ -13,7 +12,6 @@ import lombok.experimental.FieldDefaults;
  * Contact point - Lot organisation role (M:M join entity)
  */
 @Entity
-@Immutable
 @Table(name = "contact_point_lot_ors")
 @Data
 @FieldDefaults(level = AccessLevel.PRIVATE)
@@ -21,13 +19,14 @@ import lombok.experimental.FieldDefaults;
 public class ContactPointLotOrgRole {
 
   @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "contact_point_id")
   Integer id;
 
   @Column(name = "contact_point_name")
   String contactPointName;
 
-  @ManyToOne
+  @ManyToOne(cascade = CascadeType.ALL)
   @JoinColumn(name = "contact_detail_id")
   ContactDetail contactDetail;
 
@@ -35,8 +34,11 @@ public class ContactPointLotOrgRole {
   @JoinColumn(name = "contact_point_reason_id")
   ContactPointReason contactPointReason;
 
+  @Column(name = "lot_organisation_role_id")
+  int lotOrganisationRoleId;
+
   @Column(name = "effective_from")
-  LocalDate effectiveFrom;
+  LocalDate effectiveFrom = LocalDate.now();
 
   @Column(name = "effective_to")
   LocalDate effectiveTo;

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/LotOrganisationRole.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/LotOrganisationRole.java
@@ -1,11 +1,12 @@
 package uk.gov.crowncommercial.dts.scale.service.agreements.model.entity;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Set;
 import javax.persistence.*;
 
+import lombok.ToString;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Immutable;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.experimental.FieldDefaults;
@@ -14,7 +15,6 @@ import lombok.experimental.FieldDefaults;
  * Lot organisation role
  */
 @Entity
-@Immutable
 @Table(name = "lot_organisation_roles")
 @Data
 @FieldDefaults(level = AccessLevel.PRIVATE)
@@ -23,7 +23,11 @@ public class LotOrganisationRole {
 
   @Id
   @Column(name = "lot_organisation_role_id")
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   Integer id;
+
+   @Column(name = "lot_id")
+   int lotId;
 
   @ManyToOne
   @JoinColumn(name = "organisation_id")
@@ -38,6 +42,7 @@ public class LotOrganisationRole {
   @OneToMany(fetch = FetchType.LAZY)
   @JoinColumn(name = "lot_organisation_role_id")
   @org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_WRITE,region = "contactPointLotOrgRoles")
+  @ToString.Exclude
   Set<ContactPointLotOrgRole> contactPointLotOrgRoles;
 
   @ManyToOne
@@ -54,6 +59,15 @@ public class LotOrganisationRole {
   @Column(name="organisation_status")
   char status;
 
-  @Column(name = "role_type_id", insertable = false, updatable=false)
-  Integer roleTypeId;
+  @Column(name="created_by")
+  String createdBy;
+
+  @Column(name = "created_at")
+  LocalDateTime createdAt;
+
+  @Column(name="updated_by")
+  String updatedBy;
+
+  @Column(name = "updated_at")
+  LocalDateTime updatedAt;
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/Organisation.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/Organisation.java
@@ -2,20 +2,21 @@ package uk.gov.crowncommercial.dts.scale.service.agreements.model.entity;
 
 import java.time.LocalDate;
 import java.util.Set;
+import java.util.function.Function;
 import javax.persistence.*;
 
 import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Immutable;
+
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.FieldDefaults;
+import uk.gov.crowncommercial.dts.scale.service.agreements.exception.InvalidOrganisationException;
 
 /**
  * Organisation
  */
 @Entity
-@Immutable
 @Table(name = "organisations")
 @Data
 @EqualsAndHashCode(exclude = "people")
@@ -25,6 +26,7 @@ public class Organisation {
 
   @Id
   @Column(name = "organisation_id")
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   Integer id;
 
   @Column(name = "entity_id")
@@ -67,4 +69,26 @@ public class Organisation {
   @org.hibernate.annotations.Cache(usage = CacheConcurrencyStrategy.READ_WRITE,region = "people")
   Set<Person> people;
 
+  public Boolean getIsSme() {
+    return isSme != null ? isSme : Boolean.FALSE;
+  }
+
+  public Boolean getIsVcse() {
+    return isVcse != null ? isVcse : Boolean.FALSE;
+  }
+
+  public Boolean getIsActive() {
+    return isActive != null ? isActive : Boolean.FALSE;
+  }
+  public Organisation map(Function<Organisation, Organisation> function) {
+    return function.apply(this);
+  }
+
+  public void isValid(){
+    if (legalName == null || legalName.isEmpty()) {throw new InvalidOrganisationException("legalName");}
+    if (registryCode == null || registryCode.isEmpty()) {throw new InvalidOrganisationException("registryCode");}
+    if (entityId == null || entityId.isEmpty()) {throw new InvalidOrganisationException("entityId");}
+    if (incorporationDate == null) {throw new InvalidOrganisationException("incorporationDate");}
+    if (incorporationCountry == null || incorporationCountry.isEmpty()) {throw new InvalidOrganisationException("incorporationCountry");}
+  }
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/ContactPointLotOrgRoleRepo.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/ContactPointLotOrgRoleRepo.java
@@ -1,0 +1,13 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.ContactPointLotOrgRole;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.ContactPointReason;
+
+import java.util.Optional;
+
+public interface ContactPointLotOrgRoleRepo extends JpaRepository<ContactPointLotOrgRole, Integer> {
+
+    Optional<ContactPointLotOrgRole> findFirstByLotOrganisationRoleIdAndContactPointReasonOrderByIdAsc(int lotOrganisationRoleId, ContactPointReason contactPointReason);
+}
+

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/ContactPointReasonRepo.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/ContactPointReasonRepo.java
@@ -1,0 +1,9 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.ContactPointReason;
+
+public interface ContactPointReasonRepo extends JpaRepository<ContactPointReason, Integer> {
+
+    ContactPointReason findById(int Id);
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/LotOrganisationRoleRepo.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/LotOrganisationRoleRepo.java
@@ -1,0 +1,12 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.LotOrganisationRole;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.RoleType;
+
+import java.util.Optional;
+
+public interface LotOrganisationRoleRepo extends JpaRepository<LotOrganisationRole, Integer> {
+
+    Optional<LotOrganisationRole> findByLotIdAndOrganisationIdAndRoleType(int lotId, int organisationID, RoleType roleType);
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/OrganisationRepo.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/OrganisationRepo.java
@@ -1,0 +1,12 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.Organisation;
+
+import java.util.Optional;
+
+public interface OrganisationRepo extends JpaRepository<Organisation, Integer> {
+
+    Optional<Organisation> findByLegalName(String legalName);
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/RoleTypeRepo.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/RoleTypeRepo.java
@@ -1,0 +1,10 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.RoleType;
+
+public interface RoleTypeRepo extends JpaRepository<RoleType, Integer> {
+
+    RoleType findById(int id);
+
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/MappingService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/MappingService.java
@@ -108,4 +108,20 @@ public class MappingService {
     public QuestionTemplate mapProcurementQuestionTemplateToQuestionTemplate(ProcurementQuestionTemplate templateModel, Integer groupId) {
         return questionTemplateMapper.procurementQuestionTemplateToQuestionTemplate(templateModel, groupId);
     }
+
+    /**
+     * Map a LotSupplier to a Organisation
+     */
+    public Organisation mapLotSupplierToOrganisation(LotSupplier lotSupplier) {
+
+        return supplierMapper.lotSupplierToOrganisation(lotSupplier);
+    }
+
+    /**
+     * Map a LotSupplier to a ContactDetail
+     */
+    public ContactDetail mapLotSupplierToContactDetail(LotSupplier lotSupplier) {
+
+        return supplierMapper.lotSupplierToContactDetail(lotSupplier);
+    }
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/SupplierService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/SupplierService.java
@@ -1,0 +1,156 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.crowncommercial.dts.scale.service.agreements.exception.OrganisationNotFoundException;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.SupplierStatus;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.*;
+import uk.gov.crowncommercial.dts.scale.service.agreements.repository.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * Supplier Service.
+ *
+ */
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SupplierService {
+
+    @Autowired
+    private final OrganisationRepo organisationRepo;
+
+    @Autowired
+    private final LotOrganisationRoleRepo lotOrganisationRoleRepo;
+
+    @Autowired
+    private final RoleTypeRepo roleTypeRepo;
+
+    @Autowired
+    private final ContactPointLotOrgRoleRepo contactPointLotOrgRoleRepo;
+
+    @Autowired
+    private final ContactPointReasonRepo contactPointReasonRepo;
+
+    /**
+     * Find a organisation by its legal name.
+     *
+     * @param legalName Legal name of the organisation
+     * @return Organisation
+     */
+    public Organisation findOrganisationByLegalName(final String legalName) {
+        log.debug("findOrganisationByLegalName: {}", legalName);
+
+        return organisationRepo.findByLegalName(legalName).orElseThrow(() -> new OrganisationNotFoundException(legalName) );
+    }
+
+    /**
+     * Create or update the Organisation that is passed in
+     *
+     * @param newOrganisation Organisation
+     * @return Organisation
+     */
+    public Organisation createOrUpdateOrganisation(final Organisation newOrganisation) {
+        return organisationRepo.findByLegalName(newOrganisation.getLegalName())
+                .map(organisation -> {
+                    organisation.setEntityId            (newOrganisation.getEntityId());
+                    organisation.setRegistryCode        (newOrganisation.getRegistryCode());
+                    organisation.setLegalName           (newOrganisation.getLegalName());
+                    organisation.setBusinessType        (newOrganisation.getBusinessType());
+                    organisation.setUri                 (newOrganisation.getUri());
+                    organisation.setStatus              (newOrganisation.getStatus());
+                    organisation.setIncorporationDate   (newOrganisation.getIncorporationDate());
+                    organisation.setIncorporationCountry(newOrganisation.getIncorporationCountry());
+                    organisation.setCountryName         (newOrganisation.getCountryName());
+                    organisation.setIsSme               (newOrganisation.getIsSme());
+                    organisation.setIsVcse              (newOrganisation.getIsVcse());
+                    organisation.setIsActive            (newOrganisation.getIsActive());
+
+                    organisationRepo.saveAndFlush(organisation);
+                    return findOrganisationByLegalName(organisation.getLegalName());
+                }).orElseGet(() -> {
+                    organisationRepo.saveAndFlush(newOrganisation);
+                    return findOrganisationByLegalName(newOrganisation.getLegalName());
+                });
+    }
+
+
+
+
+    /**
+     * Assign relation between lot and organisation (supplier relationship)
+     * If contact detail is valid, assign contact detial relationship (streetAddress, postalCode, countryCode, countryName is not empty)
+     *
+     * @param lot Lot
+     * @param newOrganisation Organisation
+     * @param newContactDetail ContactDetail
+     * @param actionBy String
+     * @param status SupplierStatus
+     */
+    public void addSupplierRelationship(final Lot lot, Organisation newOrganisation, ContactDetail newContactDetail, String actionBy, SupplierStatus status){
+        Organisation o = this.createOrUpdateOrganisation(newOrganisation);
+
+        //      Supplier contact reason id is 3
+        ContactPointReason supplierContactReason = contactPointReasonRepo.findById(3);
+
+        //Supplier role type id is 2
+        RoleType supplierRoleType = roleTypeRepo.findById(2);
+
+        LotOrganisationRole saveLor = lotOrganisationRoleRepo.findByLotIdAndOrganisationIdAndRoleType(lot.getId(), o.getId(), supplierRoleType)
+                .map(lor -> {
+                    lor.setUpdatedAt(LocalDateTime.now());
+                    lor.setUpdatedBy(actionBy);
+                    lor.setStatus(SupplierStatus.getChar(status));
+
+                    lotOrganisationRoleRepo.saveAndFlush(lor);
+                    return lor;
+                }).orElseGet(() -> {
+                    LotOrganisationRole lor = new LotOrganisationRole();
+                    lor.setLotId(lot.getId());
+                    lor.setOrganisation(o);
+                    lor.setRoleType(supplierRoleType);
+                    lor.setStartDate(LocalDate.now());
+                    lor.setCreatedBy(actionBy);
+                    lor.setCreatedAt(LocalDateTime.now());
+                    lor.setStatus(SupplierStatus.getChar(status));
+
+                    lotOrganisationRoleRepo.saveAndFlush(lor);
+                    return lor;
+                });
+
+        if (newContactDetail != null){
+            contactPointLotOrgRoleRepo.findFirstByLotOrganisationRoleIdAndContactPointReasonOrderByIdAsc(saveLor.getId(), supplierContactReason)
+                    .map(cplor -> {
+                        ContactDetail cd = cplor.getContactDetail();
+                        cd.setEffectiveTo(newContactDetail.getEffectiveTo());
+                        cd.setStreetAddress(newContactDetail.getStreetAddress());
+                        cd.setLocality(newContactDetail.getLocality());
+                        cd.setRegion(newContactDetail.getRegion());
+                        cd.setPostalCode(newContactDetail.getPostalCode());
+                        cd.setCountryCode(newContactDetail.getCountryCode());
+                        cd.setCountryName(newContactDetail.getCountryName());
+                        cd.setUprn(newContactDetail.getUprn());
+                        cd.setEmailAddress(newContactDetail.getEmailAddress());
+                        cd.setTelephoneNumber(newContactDetail.getTelephoneNumber());
+                        cd.setFaxNumber(newContactDetail.getFaxNumber());
+                        cd.setUrl(newContactDetail.getUrl());
+                        if (newContactDetail.getName()!= null && !newContactDetail.getName().isEmpty()) { cplor.setContactPointName(newContactDetail.getName());}
+                        contactPointLotOrgRoleRepo.saveAndFlush(cplor);
+                        return cplor;
+                    }).orElseGet(() ->{
+                        ContactPointLotOrgRole cplor = new ContactPointLotOrgRole();
+                        cplor.setLotOrganisationRoleId(saveLor.getId());
+                        cplor.setContactPointReason(supplierContactReason);
+                        cplor.setContactDetail(newContactDetail);
+                        if (newContactDetail.getName()!= null && !newContactDetail.getName().isEmpty()) { cplor.setContactPointName(newContactDetail.getName());}
+                        contactPointLotOrgRoleRepo.saveAndFlush(cplor);
+                        return cplor;
+                    });
+        }
+    }
+}

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/mapping/MapStructMappingTests.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/mapping/MapStructMappingTests.java
@@ -305,4 +305,65 @@ public class MapStructMappingTests {
         assertEquals(groupId, outputModel.getTemplateGroupId());
         assertEquals(sourceModel.getTemplateName(), outputModel.getName());
     }
+
+    @Test
+    public void testLotSupplierToOrganisationWithValidScheme() throws Exception {
+        OrganizationIdentifier oi = new OrganizationIdentifier();
+        oi.setLegalName("First company ever");
+        oi.setScheme(Scheme.GBCHC);
+        oi.setId("1234567");
+
+        OrganizationDetail od = new OrganizationDetail();
+        od.setActive(true);
+        od.setCountryCode("GB");
+        od.setCreationDate(LocalDate.now());
+
+        Organization org = new Organization();
+        org.setIdentifier(oi);
+        org.setDetails(od);
+
+        LotSupplier sourceModel = new LotSupplier();
+        sourceModel.setOrganization(org);
+
+        Organisation outputModel = supplierMapper.lotSupplierToOrganisation(sourceModel);
+
+        assertNotNull(outputModel);
+        assertEquals(sourceModel.getOrganization().getIdentifier().getLegalName(), outputModel.getLegalName());
+        assertEquals(sourceModel.getOrganization().getIdentifier().getId(), outputModel.getEntityId());
+        assertEquals(sourceModel.getOrganization().getIdentifier().getScheme().getName(), outputModel.getRegistryCode());
+        assertEquals(sourceModel.getOrganization().getDetails().getCountryCode(), outputModel.getIncorporationCountry());
+        assertEquals(sourceModel.getOrganization().getDetails().getActive(), outputModel.getIsActive());
+    }
+
+    @Test
+    public void testLotSupplierToContactDetail() throws Exception {
+        Address add = new Address();
+        add.setStreetAddress("Street Name");
+        add.setPostalCode("ABC123");
+        add.setCountryCode("GB");
+        add.setCountryName("United Kingdom");
+        ContactPoint cp = new ContactPoint();
+        cp.setName("Person Incharge");
+        cp.setEmail("Test@email.com");
+        cp.setTelephone("0123456789");
+        cp.setFaxNumber("6574839201");
+        cp.setUrl("www.url.co.uk");
+
+        Organization org = new Organization();
+        org.setAddress(add);
+        org.setContactPoint(cp);
+
+        LotSupplier sourceModel = new LotSupplier();
+        sourceModel.setOrganization(org);
+
+
+        ContactDetail outputModel = supplierMapper.lotSupplierToContactDetail(sourceModel);
+
+        assertNotNull(outputModel);
+        assertEquals(sourceModel.getOrganization().getAddress().getStreetAddress(), outputModel.getStreetAddress());
+        assertEquals(sourceModel.getOrganization().getAddress().getPostalCode(), outputModel.getPostalCode());
+        assertEquals(sourceModel.getOrganization().getContactPoint().getName(), outputModel.getName());
+        assertEquals(sourceModel.getOrganization().getContactPoint().getEmail(), outputModel.getEmailAddress());
+        assertEquals(sourceModel.getOrganization().getContactPoint().getUrl(), outputModel.getUrl());
+    }
 }

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/SupplierServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/SupplierServiceTest.java
@@ -1,0 +1,203 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.core.AutoConfigureCache;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.crowncommercial.dts.scale.service.agreements.config.EhcacheConfig;
+import uk.gov.crowncommercial.dts.scale.service.agreements.exception.OrganisationNotFoundException;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.*;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.*;
+import uk.gov.crowncommercial.dts.scale.service.agreements.repository.*;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureCache
+@ExtendWith(MockitoExtension.class)
+public class SupplierServiceTest {
+    @MockBean
+    private EhcacheConfig cacheConfig;
+
+    private static final String AGREEMENT_NUMBER = "RM1000";
+    private static final String LOT_NUMBER = "Lot 1";
+    private static final String COMPANY_NAME = "A Company Name";
+
+    @Autowired
+    SupplierService supplierService;
+
+    @MockBean
+    private OrganisationRepo mockOrganisationRepo;
+
+    @MockBean
+    private LotOrganisationRoleRepo mockLotOrganisationRoleRepo;
+
+    @MockBean
+    private ContactPointLotOrgRoleRepo mockContactPointLotOrgRoleRepo;
+
+    @MockBean
+    private RoleTypeRepo mockRoleTypeRepo;
+
+    @MockBean
+    private Organisation mockOrganisation;
+
+    @MockBean
+    private Lot mockLot;
+
+    @Test
+    void testGetOrganisation() throws Exception {
+        when(mockOrganisationRepo.findByLegalName(COMPANY_NAME)).thenReturn(Optional.ofNullable(mockOrganisation));
+        assertEquals(mockOrganisation, supplierService.findOrganisationByLegalName(COMPANY_NAME));
+    }
+
+    @Test
+    void testGetOrganisationNotFound() throws Exception {
+        when(mockOrganisationRepo.findByLegalName(COMPANY_NAME)).thenReturn(Optional.ofNullable(null));
+
+        OrganisationNotFoundException thrown = Assertions.assertThrows(
+                OrganisationNotFoundException.class,
+                () -> supplierService.findOrganisationByLegalName(COMPANY_NAME),
+                "Organisation with legal name of 'A Company Name' not found"
+        );
+
+        assertTrue(thrown.getMessage().contains("not found"));
+    }
+
+    @Test
+    void testCreateOrganisation() throws Exception {
+
+        Organisation org = new Organisation();
+        org.setLegalName(COMPANY_NAME);
+        org.setRegistryCode(Scheme.GBCHC.getName());
+        org.setEntityId("123456");
+        org.setIncorporationDate(LocalDate.now());
+        org.setIncorporationCountry("GB");
+
+        when(mockOrganisationRepo.findByLegalName(COMPANY_NAME)).thenReturn(Optional.ofNullable(null)).thenReturn(Optional.ofNullable(org));
+
+        Organisation result = supplierService.createOrUpdateOrganisation(org);
+        assertEquals(result.getLegalName(), org.getLegalName());
+        assertEquals(result.getRegistryCode(), org.getRegistryCode());
+        assertEquals(result.getEntityId(), org.getEntityId());
+        assertEquals(result.getIncorporationCountry(), org.getIncorporationCountry());
+        assertEquals(result.getIncorporationDate(), org.getIncorporationDate());
+    }
+
+    Organisation setupOrg(){
+        Organisation org = new Organisation();
+        org.setId(123);
+        org.setLegalName(COMPANY_NAME);
+        org.setRegistryCode(Scheme.GBCHC.getName());
+        org.setEntityId("123456");
+        org.setIncorporationDate(LocalDate.now());
+        org.setIncorporationCountry("GB");
+        org.setIsActive(true);
+
+        return org;
+    }
+
+    ContactDetail setupCd(){
+        ContactDetail cd = new ContactDetail();
+        cd.setName("Some name");
+        cd.setEmailAddress("some@email.com");
+        cd.setStreetAddress("Street name");
+        cd.setPostalCode("SW1");
+        cd.setCountryCode("GB");
+        cd.setCountryName("UK");
+
+        return cd;
+    }
+
+    @Test
+    void testUpdateOrganisation() throws Exception {
+
+        Organisation org = setupOrg();
+
+        when(mockOrganisationRepo.findByLegalName(COMPANY_NAME)).thenReturn(Optional.ofNullable(org)).thenReturn(Optional.ofNullable(org));
+
+        Organisation result = supplierService.createOrUpdateOrganisation(org);
+        assertEquals(result.getLegalName(), org.getLegalName());
+        assertEquals(result.getRegistryCode(), org.getRegistryCode());
+        assertEquals(result.getEntityId(), org.getEntityId());
+        assertEquals(result.getIncorporationCountry(), org.getIncorporationCountry());
+        assertEquals(result.getIncorporationDate(), org.getIncorporationDate());
+        assertEquals(result.getIsActive(), org.getIsActive());
+    }
+
+    @Test
+    void testAddSupplierWithoutContact_createRelationship() throws Exception {
+
+        Organisation org = setupOrg();
+
+        when(mockOrganisationRepo.findByLegalName(COMPANY_NAME)).thenReturn(Optional.ofNullable(org)).thenReturn(Optional.ofNullable(org));
+        when(mockLotOrganisationRoleRepo.findByLotIdAndOrganisationIdAndRoleType(mockLot.getId(),org.getId(), null)).thenReturn(Optional.ofNullable(null));
+
+        supplierService.addSupplierRelationship(mockLot, org, null, "Local Test", SupplierStatus.ACTIVE);
+
+        verify(mockLotOrganisationRoleRepo, times(1)).saveAndFlush(ArgumentMatchers.any(LotOrganisationRole.class));
+    }
+
+    @Test
+    void testAddSupplierWithoutContact_updateRelationship() throws Exception {
+
+        Organisation org = setupOrg();
+
+        when(mockOrganisationRepo.findByLegalName(COMPANY_NAME)).thenReturn(Optional.ofNullable(org)).thenReturn(Optional.ofNullable(org));
+        when(mockLotOrganisationRoleRepo.findByLotIdAndOrganisationIdAndRoleType(mockLot.getId(),org.getId(), null)).thenReturn(Optional.ofNullable(new LotOrganisationRole()));
+
+        supplierService.addSupplierRelationship(mockLot, org, null, "Local Test", SupplierStatus.ACTIVE);
+
+        verify(mockLotOrganisationRoleRepo, times(1)).saveAndFlush(ArgumentMatchers.any(LotOrganisationRole.class));
+    }
+
+    @Test
+    void testAddSupplierWithContact_createRelationship() throws Exception {
+
+        Organisation org = setupOrg();
+        ContactDetail cd = setupCd();
+        LotOrganisationRole lor = new LotOrganisationRole();
+        lor.setId(1234);
+
+        when(mockOrganisationRepo.findByLegalName(COMPANY_NAME)).thenReturn(Optional.ofNullable(org)).thenReturn(Optional.ofNullable(org));
+        when(mockLotOrganisationRoleRepo.findByLotIdAndOrganisationIdAndRoleType(mockLot.getId(),org.getId(), null)).thenReturn(Optional.ofNullable(lor));
+        when(mockContactPointLotOrgRoleRepo.findFirstByLotOrganisationRoleIdAndContactPointReasonOrderByIdAsc(ArgumentMatchers.any(Integer.class), ArgumentMatchers.any(ContactPointReason.class))).thenReturn(null);
+
+        supplierService.addSupplierRelationship(mockLot, org, cd, "Local Test", SupplierStatus.ACTIVE);
+
+        verify(mockContactPointLotOrgRoleRepo, times(1)).saveAndFlush(ArgumentMatchers.any(ContactPointLotOrgRole.class));
+    }
+
+    @Test
+    void testAddSupplierWithContact_updateRelationship() throws Exception {
+
+        Organisation org = setupOrg();
+        ContactDetail cd = setupCd();
+        LotOrganisationRole lor = new LotOrganisationRole();
+        lor.setId(1234);
+
+        ContactPointLotOrgRole cplor = new ContactPointLotOrgRole();
+        cplor.setContactDetail(cd);
+
+
+        when(mockOrganisationRepo.findByLegalName(COMPANY_NAME)).thenReturn(Optional.ofNullable(org)).thenReturn(Optional.ofNullable(org));
+        when(mockLotOrganisationRoleRepo.findByLotIdAndOrganisationIdAndRoleType(mockLot.getId(), org.getId(), null)).thenReturn(Optional.ofNullable(lor));
+        when(mockContactPointLotOrgRoleRepo.findFirstByLotOrganisationRoleIdAndContactPointReasonOrderByIdAsc(1234, null)).thenReturn(Optional.of(cplor));
+
+
+        supplierService.addSupplierRelationship(mockLot, org, cd, "Local Test", SupplierStatus.ACTIVE);
+
+        verify(mockContactPointLotOrgRoleRepo, times(1)).saveAndFlush(ArgumentMatchers.any(ContactPointLotOrgRole.class));
+    }
+}


### PR DESCRIPTION
http://localhost:9010/agreements-service/agreements/RM6194/lots/1/suppliers
You can call the endpoint above to create a new supplier relationship. The example below contains the full detailed supplier relationship.

```
[
    {
        "supplierStatus": "active",
        "lastUpdatedBy": "local macbook",
        "organization": {
            "identifier": {
                "scheme": "GB-COH",
                "id": "579320",
                "legalName": "New supplier here",
                "uri": "www.new-sup.co.uk"
            },
            "details": {
                "creationDate": "2000-11-11",
                "countryCode": "GB",
                "is_sme": false,
                "is_vcse": true,
                "active": true
            },
            "address": {
                "streetAddress": "new street",
                "locality": "locality",
                "region": "region",
                "postalCode": "SE1 0PY",
                "countryName": "United Kingdom",
                "countryCode": "GB",
                "uprn": 1
            },
            "contactPoint": {
                "name": "Its just a name",
                "email": "name@email.com",
                "telephone": "54585932",
                "faxNumber": "34213",
                "url": "www.name-team.co.uk"
            }
        }
    }
]
```

To add a supplier relationship without the contact detail, you can use the following structure.

```
[
    {
        "organization": {
            "identifier": {
                "scheme": "US-DUNS",
                "id": "0987654321",
                "legalName": "another company",
                "uri": "www.anotherCompany.co.uk"
            },
            "details": {
                "creationDate": "2012-12-12",
                "countryCode": "GB",
                "is_sme": false,
                "is_vcse": true,
                "active": true
            }
        },
        "supplierStatus": "active",
        "lastUpdatedBy": "Chee"
    }
]
```

This endpoint also allows multiple suppliers to be added at once so you can essentially combine the first and second code snippets together. Like this:
```
[
    {
        "supplierStatus": "active",
        "lastUpdatedBy": "local macbook",
        "organization": {
            "identifier": {
                "scheme": "GB-COH",
                "id": "579320",
                "legalName": "New supplier here",
                "uri": "www.new-sup.co.uk"
            },
            "details": {
                "creationDate": "2000-11-11",
                "countryCode": "GB",
                "is_sme": false,
                "is_vcse": true,
                "active": true
            },
            "address": {
                "streetAddress": "new street",
                "locality": "locality",
                "region": "region",
                "postalCode": "SE1 0PY",
                "countryName": "United Kingdom",
                "countryCode": "GB",
                "uprn": 1
            },
            "contactPoint": {
                "name": "Its just a name",
                "email": "name@email.com",
                "telephone": "54585932",
                "faxNumber": "34213",
                "url": "www.name-team.co.uk"
            }
        }
    },
        {
        "organization": {
            "identifier": {
                "scheme": "US-DUNS",
                "id": "0987654321",
                "legalName": "another company",
                "uri": "www.anotherCompany.co.uk"
            },
            "details": {
                "creationDate": "2012-12-12",
                "countryCode": "GB",
                "is_sme": false,
                "is_vcse": true,
                "active": true
            }
        },
        "supplierStatus": "active",
        "lastUpdatedBy": "Chee"
    }
]
```