### PR TITLE
added patch enpoint for supplier detail 

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/BLL/BusinessLogicClient.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/BLL/BusinessLogicClient.java
@@ -324,4 +324,35 @@ public class BusinessLogicClient {
 
         return new SupplierSummary(LocalDate.now(), lastUpdatedBy, getLotSuppliers(agreementId, lotId).size());        
     }
+
+    /**
+     * Returns a specific Organization object based on a requested name
+    */
+    @Cacheable(value = "getOrganizationIdentifier")
+    public OrganizationIdentifier getOrganisation(String organisationName) {
+        OrganizationIdentifier model = null;
+
+        Organisation organisation = supplierService.findOrganisationByLegalName(organisationName);
+
+        if (organisation != null) {
+            model = mappingService.mapOrganisationToOrganizationIdentifier(organisation);
+        }
+
+        return model;
+    }
+
+    /**
+     * Returns an updated Organization Identifier based on the request body
+     * Clear cache after its being called
+    */
+    @CacheEvict(value = { "getOrganizationIdentifier" }, allEntries = true)
+    public OrganizationIdentifier partialSaveOrganisation(String organisationName, OrganizationIdentifier organizationIdentifier){
+
+        final Organisation organisation = mappingService.mapOrganizationIdentifierToOrganisation(organizationIdentifier);
+        organisation.isValidForPartialUpdate();
+        
+        String orgName = supplierService.partialSaveOrganisation(organisationName, organisation);
+
+        return getOrganisation(orgName);
+    }
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/config/EhcacheConfig.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/config/EhcacheConfig.java
@@ -51,6 +51,7 @@ public class EhcacheConfig {
         cacheManager.createCache("getLotEventTypes", primaryCacheConfig);
         cacheManager.createCache("getEventDataTemplates", primaryCacheConfig);
         cacheManager.createCache("getEventDocumentTemplates", primaryCacheConfig);
+        cacheManager.createCache("getOrganizationIdentifier", primaryCacheConfig);
 
         // Establish secondary caches
         cacheManager.createCache("getLotSuppliers", secondaryCacheConfig);

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/OrganisationController.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/OrganisationController.java
@@ -1,0 +1,36 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+import uk.gov.crowncommercial.dts.scale.service.agreements.BLL.BusinessLogicClient;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.*;
+
+/**
+ * Organisation Controller
+ */
+@RestController
+@RequestMapping("/organisation")
+@RequiredArgsConstructor
+@Slf4j
+public class OrganisationController {
+    @Autowired
+    private BusinessLogicClient businessLogicClient;
+
+    @GetMapping("/identifier/{OrganisationName}")
+    public OrganizationIdentifier getOrganisation(@PathVariable(value = "OrganisationName") final String OrganisationName) {
+    log.debug("getOrganisation called with values: OrganisationName={}", OrganisationName);
+
+    OrganizationIdentifier model = businessLogicClient.getOrganisation(OrganisationName);
+
+    return model;
+  }
+
+  @PatchMapping("/identifier/{OrganisationName}")
+  public OrganizationIdentifier partialUpdateOrganisation(@PathVariable(value = "OrganisationName") final String OrganisationName, @RequestBody OrganizationIdentifier organizationIdentifier) {
+    log.debug("partialUpdateOrganisation called with values: OrganisationName={}", OrganisationName);
+
+    return businessLogicClient.partialSaveOrganisation(OrganisationName, organizationIdentifier);
+  }
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/exception/InvalidOrganisationException.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/exception/InvalidOrganisationException.java
@@ -3,8 +3,18 @@ package uk.gov.crowncommercial.dts.scale.service.agreements.exception;
 public class InvalidOrganisationException extends RuntimeException {
     private static final long serialVersionUID = 1L;
     public static final String ERROR_MSG_TEMPLATE = "Invalid organisation format, missing '%s'";
+    public static final String ERROR_MSG_TEMPLATE_EXISTED = "Organisation with '%s': '%s', already exist";
+    public static final String ERROR_MSG_TEMPLATE_EMPTY = "Organisation body must have either legalName or a valid scheme with id in the body";
+
+    public InvalidOrganisationException() {
+        super(String.format(ERROR_MSG_TEMPLATE_EMPTY));
+    }
 
     public InvalidOrganisationException(final String missingField) {
         super(String.format(ERROR_MSG_TEMPLATE, missingField));
+    }
+
+    public InvalidOrganisationException(final String field, String value) {
+        super(String.format(ERROR_MSG_TEMPLATE_EXISTED, field, value));
     }
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/exception/OrganisationNotFoundException.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/exception/OrganisationNotFoundException.java
@@ -4,8 +4,13 @@ public class OrganisationNotFoundException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
     public static final String ERROR_MSG_TEMPLATE = "Organisation with legal name of '%s' not found";
+    public static final String ERROR_MSG_TEMPLATE_SCHEME_ENTITY_ID = "Organisation with '%s': '%s' not found";
 
     public OrganisationNotFoundException(final String legalName) {
         super(String.format(ERROR_MSG_TEMPLATE, legalName));
+    }
+
+    public OrganisationNotFoundException(final String scheme, final String entityId) {
+        super(String.format(ERROR_MSG_TEMPLATE_SCHEME_ENTITY_ID, scheme,entityId));
     }
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/mapping/LotSupplierMapper.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/mapping/LotSupplierMapper.java
@@ -33,7 +33,14 @@ public abstract class LotSupplierMapper {
     @Mapping(source = "isActive", target = "active")
     public abstract OrganizationDetail organisationToOrganizationDetail(Organisation orgModel);
 
+    @Mapping(source = "registryCode", target = "scheme", qualifiedByName = "registryCodeToOrgScheme")
+    @Mapping(source = "entityId", target = "id")
+    public abstract OrganizationIdentifier OrganisationToOrganizationIdentifier(Organisation orgModel);
 
+    @Mapping(source = "scheme", target = "registryCode", qualifiedByName = "schemeToRegistryCodeWithoutError")
+    @Mapping(source = "id", target = "entityId")
+    @Mapping(ignore = true, target = "id")
+    public abstract Organisation OrganizationIdentifierToOrganisation(OrganizationIdentifier orgModel);
 
     @Mapping(source = "organization.address.streetAddress", target = "streetAddress")
     @Mapping(source = "organization.address.locality", target = "locality")
@@ -85,6 +92,15 @@ public abstract class LotSupplierMapper {
             throw new InvalidSchemeExpection();
         }
 
+    }
+
+    @Named("schemeToRegistryCodeWithoutError")
+    public static String schemeToRegistryCodeStringWithoutError(Scheme scheme) {
+
+        if (scheme != null){
+            return scheme.getName();
+        }
+        return null;
     }
 
     @Mapping(target="id", source="orgModel.entityId")

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/Organisation.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/Organisation.java
@@ -88,4 +88,12 @@ public class Organisation {
     if (incorporationDate == null) {throw new InvalidOrganisationException("incorporationDate");}
     if (incorporationCountry == null || incorporationCountry.isEmpty()) {throw new InvalidOrganisationException("incorporationCountry");}
   }
+
+  public void isValidForPartialUpdate(){
+
+    if (legalName != null && !legalName.isEmpty() || entityId != null && !entityId.isEmpty() && registryCode != null && !registryCode.isEmpty()) {
+    } else {
+      throw new InvalidOrganisationException();
+    }
+  }
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/OrganisationRepo.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/repository/OrganisationRepo.java
@@ -9,4 +9,5 @@ public interface OrganisationRepo extends JpaRepository<Organisation, Integer> {
 
     Optional<Organisation> findByLegalName(String legalName);
 
+    Optional<Organisation> findByRegistryCodeAndEntityId(String Scheme, String entityId);
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/MappingService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/MappingService.java
@@ -124,4 +124,20 @@ public class MappingService {
 
         return supplierMapper.lotSupplierToContactDetail(lotSupplier);
     }
+
+    /**
+     * Map a Organisation to a Organization Identifier
+     */
+    public OrganizationIdentifier mapOrganisationToOrganizationIdentifier(Organisation organisation) {
+
+        return supplierMapper.OrganisationToOrganizationIdentifier(organisation);
+    }
+
+    /**
+     * Map a Organization Identifier to a Organisation
+     */
+    public Organisation mapOrganizationIdentifierToOrganisation(OrganizationIdentifier organizationIdentifier) {
+
+        return supplierMapper.OrganizationIdentifierToOrganisation(organizationIdentifier);
+    }
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/SupplierService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/SupplierService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import uk.gov.crowncommercial.dts.scale.service.agreements.exception.OrganisationNotFoundException;
+import uk.gov.crowncommercial.dts.scale.service.agreements.exception.*;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.SupplierStatus;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.*;
 import uk.gov.crowncommercial.dts.scale.service.agreements.repository.*;
@@ -47,6 +47,19 @@ public class SupplierService {
         log.debug("findOrganisationByLegalName: {}", legalName);
 
         return organisationRepo.findByLegalName(legalName).orElseThrow(() -> new OrganisationNotFoundException(legalName) );
+    }
+
+    /**
+     * Find a organisation by its legal name.
+     *
+     * @param scheme scheme of the organisation
+     * @param entityId entity ID of the organisation
+     * @return Organisation
+     */
+    public Organisation findOrganisationBySchemeAndEntityId(final String scheme, final String entityId) {
+        log.debug("findOrganisationBySchemeAndEntityId: {}", scheme, entityId);
+
+        return organisationRepo.findByRegistryCodeAndEntityId(scheme, entityId).orElseThrow(() -> new OrganisationNotFoundException(scheme, entityId) );
     }
 
     /**
@@ -152,5 +165,44 @@ public class SupplierService {
                         return cplor;
                     });
         }
+    }
+
+    /**
+     * find the existing organisation 
+     * try update its name if the new name is not taken by another organisation
+     * try to update its registry code and entity id if is not taken by another organisation 
+     *
+     * @param organisationName the existing organisation name
+     * @param organisation organisation with the detail you want to update
+     * @return a string of either the updated name or the existing organisation's name
+     */
+    public String partialSaveOrganisation(String organisationName, Organisation organisation){
+        Organisation existingOrganisation = findOrganisationByLegalName(organisationName);
+        
+        String newName = organisation.getLegalName();
+        String newRegistryCode = organisation.getRegistryCode();
+        String newEntityId = organisation.getEntityId();
+
+        try{
+            if(newName != null){
+                findOrganisationByLegalName(newName);
+                throw new InvalidOrganisationException("legal name", newName);
+            }
+        }catch(OrganisationNotFoundException e ){
+            existingOrganisation.setLegalName(newName);
+        }
+
+        try{
+            if(newRegistryCode != null && newEntityId != null){
+                findOrganisationBySchemeAndEntityId(newRegistryCode, newEntityId);
+                throw new InvalidOrganisationException("scheme:id", newRegistryCode + ":"+ newEntityId);
+            }
+        }catch(OrganisationNotFoundException e ){
+            existingOrganisation.setRegistryCode(organisation.getRegistryCode());
+            existingOrganisation.setEntityId(organisation.getEntityId());
+        }
+
+        organisationRepo.saveAndFlush(existingOrganisation);
+        return newName == null ? existingOrganisation.getLegalName() : newName;
     }
 }

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/OrganisationControllerTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/OrganisationControllerTest.java
@@ -1,0 +1,235 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.rollbar.notifier.Rollbar;
+
+import uk.gov.crowncommercial.dts.scale.service.agreements.BLL.BusinessLogicClient;
+import uk.gov.crowncommercial.dts.scale.service.agreements.exception.*;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.OrganizationIdentifier;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.Scheme;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.Organisation;
+import uk.gov.crowncommercial.dts.scale.service.agreements.service.SupplierService;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(OrganisationController.class)
+@Import(GlobalErrorHandler.class)
+public class OrganisationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SupplierService service;
+
+    @Autowired
+    private OrganisationController controller;
+
+    @MockBean
+    private BusinessLogicClient businessLogicClient;
+
+    @MockBean
+    private Organisation mockOrganisation;
+
+    @MockBean
+    private Rollbar rollbar;
+
+    private static final Scheme ENTITY = Scheme.GBCHC;
+    private static final String ID = "123456789";
+    private static final String LEGAL_NAME = "New Company";
+
+    @Test
+    void testGetOrganisationSuccess() throws Exception {
+        final OrganizationIdentifier organizationIdentifier = new OrganizationIdentifier();
+        organizationIdentifier.setLegalName(LEGAL_NAME);
+
+        when(service.findOrganisationByLegalName(LEGAL_NAME)).thenReturn(mockOrganisation);
+        when(controller.getOrganisation(LEGAL_NAME)).thenReturn(organizationIdentifier);
+        mockMvc.perform(get("/organisation/identifier/" + LEGAL_NAME))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.legalName", is(LEGAL_NAME)));
+    }
+
+    @Test
+    void testGetOrganisationNotFound() throws Exception {
+
+        when(service.findOrganisationByLegalName(LEGAL_NAME)).thenReturn(null);
+
+        when(controller.getOrganisation(LEGAL_NAME)).thenThrow(new OrganisationNotFoundException(LEGAL_NAME));
+
+        mockMvc.perform(get("/organisation/identifier/" + LEGAL_NAME))
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.NOT_FOUND.toString())))
+                .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_TITLE)))
+                .andExpect(jsonPath("$.errors[0].detail",
+                        is(String.format(OrganisationNotFoundException.ERROR_MSG_TEMPLATE, LEGAL_NAME))))
+                .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_NOT_FOUND_DESCRIPTION)));
+    }
+
+    @Test
+    void testUpdateOrganisationValidName() throws Exception {
+
+        final String newName = "New organisation name";
+
+        OrganizationIdentifier input = new OrganizationIdentifier();
+        input.setLegalName(LEGAL_NAME);
+
+        OrganizationIdentifier output = new OrganizationIdentifier();
+        output.setLegalName(newName);
+
+        when(controller.partialUpdateOrganisation(LEGAL_NAME, input)).thenReturn(output);
+
+        mockMvc.perform(MockMvcRequestBuilders
+                .patch("/organisation/identifier/" + LEGAL_NAME)
+                .content(asJsonString(input))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.legalName", is(newName)));
+    }
+
+    @Test
+    void testUpdateOrganisationValidSchemeAndId() throws Exception {
+
+        OrganizationIdentifier input = new OrganizationIdentifier();
+        input.setId(ID);
+        input.setScheme(ENTITY);
+
+        OrganizationIdentifier output = new OrganizationIdentifier();
+        output.setScheme(ENTITY);
+        output.setId(ID);
+
+        when(controller.partialUpdateOrganisation(LEGAL_NAME, input)).thenReturn(output);
+
+        mockMvc.perform(MockMvcRequestBuilders
+                .patch("/organisation/identifier/" + LEGAL_NAME)
+                .content(asJsonString(input))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.scheme", is(ENTITY.getName())))
+                .andExpect(jsonPath("$.id", is(ID)));
+    }
+
+    @Test
+    void testUpdateOrganisationValidSchemeAndIdAndName() throws Exception {
+
+        OrganizationIdentifier input = new OrganizationIdentifier();
+        input.setLegalName(LEGAL_NAME);
+        input.setId(ID);
+        input.setScheme(ENTITY);
+
+        OrganizationIdentifier output = new OrganizationIdentifier();
+        output.setLegalName(LEGAL_NAME);
+        output.setScheme(ENTITY);
+        output.setId(ID);
+
+        when(controller.partialUpdateOrganisation(LEGAL_NAME, input)).thenReturn(output);
+
+        mockMvc.perform(MockMvcRequestBuilders
+                .patch("/organisation/identifier/" + LEGAL_NAME)
+                .content(asJsonString(input))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.scheme", is(ENTITY.getName())))
+                .andExpect(jsonPath("$.id", is(ID)))
+                .andExpect(jsonPath("$.legalName", is(LEGAL_NAME)));
+    }
+
+    @Test
+    void testUpdateOrganisationValidSchemeOnly() throws Exception {
+
+        OrganizationIdentifier input = new OrganizationIdentifier();
+        input.setScheme(ENTITY);
+
+        when(controller.partialUpdateOrganisation(LEGAL_NAME, input)).thenThrow(new InvalidOrganisationException());
+
+        mockMvc.perform(MockMvcRequestBuilders
+                .patch("/organisation/identifier/" + LEGAL_NAME)
+                .content(asJsonString(input))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.BAD_REQUEST.toString())))
+                .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_VALIDATION_TITLE)))
+                .andExpect(jsonPath("$.errors[0].detail",
+                        is(String.format(InvalidOrganisationException.ERROR_MSG_TEMPLATE_EMPTY))))
+                .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_VALIDATION_DESCRIPTION)));
+    }
+
+    @Test
+    void testUpdateOrganisationInvalidName() throws Exception {
+
+        OrganizationIdentifier input = new OrganizationIdentifier();
+        input.setLegalName(LEGAL_NAME);
+
+        when(controller.partialUpdateOrganisation(LEGAL_NAME, input))
+                .thenThrow(new InvalidOrganisationException("legal name", LEGAL_NAME));
+
+        mockMvc.perform(MockMvcRequestBuilders
+                .patch("/organisation/identifier/" + LEGAL_NAME)
+                .content(asJsonString(input))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.BAD_REQUEST.toString())))
+                .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_VALIDATION_TITLE)))
+                .andExpect(jsonPath("$.errors[0].detail",
+                        is(String.format(InvalidOrganisationException.ERROR_MSG_TEMPLATE_EXISTED, "legal name",
+                                LEGAL_NAME))))
+                .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_VALIDATION_DESCRIPTION)));
+    }
+
+    @Test
+    void testUpdateOrganisationInvalidSchemeAndId() throws Exception {
+
+        OrganizationIdentifier input = new OrganizationIdentifier();
+        input.setScheme(ENTITY);
+        input.setId(ID);
+
+        String errorString = ENTITY.getName() + ":" + ID;
+        when(controller.partialUpdateOrganisation(LEGAL_NAME, input))
+                .thenThrow(new InvalidOrganisationException("scheme:id", errorString));
+
+        mockMvc.perform(MockMvcRequestBuilders
+                .patch("/organisation/identifier/" + LEGAL_NAME)
+                .content(asJsonString(input))
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().is4xxClientError())
+                .andExpect(jsonPath("$.errors[0].status", is(HttpStatus.BAD_REQUEST.toString())))
+                .andExpect(jsonPath("$.errors[0].title", is(GlobalErrorHandler.ERR_MSG_VALIDATION_TITLE)))
+                .andExpect(jsonPath("$.errors[0].detail",
+                        is(String.format(InvalidOrganisationException.ERROR_MSG_TEMPLATE_EXISTED, "scheme:id",
+                                errorString))))
+                .andExpect(jsonPath("$.description", is(GlobalErrorHandler.ERR_MSG_VALIDATION_DESCRIPTION)));
+    }
+
+    public static String asJsonString(final Object obj) {
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.registerModule(new JavaTimeModule());
+            return objectMapper.writeValueAsString(obj);
+        } catch (Exception e) {
+
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/mapping/MapStructMappingTests.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/mapping/MapStructMappingTests.java
@@ -366,4 +366,49 @@ public class MapStructMappingTests {
         assertEquals(sourceModel.getOrganization().getContactPoint().getEmail(), outputModel.getEmailAddress());
         assertEquals(sourceModel.getOrganization().getContactPoint().getUrl(), outputModel.getUrl());
     }
+
+    @Test
+    public void testOrganisationToOrganizationIdentifier() throws Exception {
+        Organisation sourceModel = new Organisation();
+        sourceModel.setLegalName(format(ORG_LEGAL_NAME, 1));
+        sourceModel.setEntityId(format(ORG_ENTITY_ID, 1));
+        sourceModel.setRegistryCode("GB-COH");
+
+        OrganizationIdentifier outputModel = supplierMapper.OrganisationToOrganizationIdentifier(sourceModel);
+
+        assertNotNull(outputModel);
+        assertEquals(sourceModel.getLegalName(), outputModel.getLegalName());
+        assertEquals(sourceModel.getEntityId(), outputModel.getId());
+        assertEquals(sourceModel.getRegistryCode(), outputModel.getScheme().getName());
+    }
+
+    @Test
+    public void testOrganisationToOrganizationIdentifierWithoutScheme() throws Exception {
+        Organisation sourceModel = new Organisation();
+        sourceModel.setLegalName(format(ORG_LEGAL_NAME, 1));
+        sourceModel.setEntityId(format(ORG_ENTITY_ID, 1));
+
+        OrganizationIdentifier outputModel = supplierMapper.OrganisationToOrganizationIdentifier(sourceModel);
+
+        assertNotNull(outputModel);
+        assertEquals(sourceModel.getLegalName(), outputModel.getLegalName());
+        assertEquals(sourceModel.getEntityId(), outputModel.getId());
+        assertEquals(sourceModel.getRegistryCode(), null);
+    }
+
+    @Test
+    public void testOrganizationIdentifierToOrganisation() throws Exception {
+
+        OrganizationIdentifier sourceModel = new OrganizationIdentifier();
+        sourceModel.setLegalName(format(ORG_LEGAL_NAME, 1));
+        sourceModel.setId(format(ORG_ENTITY_ID, 1));
+        sourceModel.setScheme(Scheme.GBCHC);
+
+        Organisation outputModel = supplierMapper.OrganizationIdentifierToOrganisation(sourceModel);
+
+        assertNotNull(outputModel);
+        assertEquals(sourceModel.getLegalName(), outputModel.getLegalName());
+        assertEquals(sourceModel.getId(), outputModel.getEntityId());
+        assertEquals(sourceModel.getScheme().getName(), outputModel.getRegistryCode());
+    }
 }


### PR DESCRIPTION
http://localhost:9010/agreements-service/organisation/identifier/{existingCompanyLegalName}


**If you want to update the name of the supplier**
```
{
    "legalName": "dada"
}
```

**If you want to update the scheme and the id for the supplier**
```
{
    "scheme": "GB-SC",
    "id": "22599195111",
}
```

**If you want to update the name scheme and id of a supplier (very unlikely)**
```
{
    "scheme": "GB-SC",
    "id": "22599195111",
    "legalName": "dada"
}
```