### PR TITLE
added regulation and agreementType

### DIFF
--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/GlobalErrorHandler.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/controller/GlobalErrorHandler.java
@@ -37,7 +37,7 @@ public class GlobalErrorHandler implements ErrorController {
 
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   @ExceptionHandler({ValidationException.class, HttpMessageNotReadableException.class,
-      MethodArgumentTypeMismatchException.class, InvalidAgreementException.class, InvalidLotException.class, InvalidSchemeExpection.class, InvalidOrganisationException.class, InvalidContactDetailExpection.class})
+      MethodArgumentTypeMismatchException.class, InvalidAgreementException.class, InvalidLotException.class, InvalidSchemeExpection.class, InvalidOrganisationException.class, InvalidContactDetailExpection.class, InvalidRegulationException.class,  InvalidAgreementTypeException.class})
   public ApiErrors handleValidationException(final Exception exception) {
 
     rollbar.warning(exception, "Request validation exception");

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/exception/InvalidAgreementTypeException.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/exception/InvalidAgreementTypeException.java
@@ -1,0 +1,21 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.exception;
+
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.Regulation;
+
+public class InvalidAgreementTypeException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+    public static final String ERROR_MSG_TEMPLATE = "Invalid agreementType '%s' passed in. agreementType must be one of the following: [Dynamic Purchasing System, Dynamic Market, Open Framework, Closed Framework, PCR15 Framework, PCR06 Framework]";
+    public static final String ERROR_MSG_TEMPLATE_FOR_REGULATION = "agreementType must be one of the following: '%s' for '%s'";
+
+    public InvalidAgreementTypeException(final String agreementType) {
+        super(String.format(ERROR_MSG_TEMPLATE, agreementType));
+    }
+
+    public InvalidAgreementTypeException(final String allowList, final Regulation regulation) {
+        super(String.format(ERROR_MSG_TEMPLATE_FOR_REGULATION, allowList, regulation.getName()));
+    }
+}
+
+
+

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/exception/InvalidRegulationException.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/exception/InvalidRegulationException.java
@@ -1,0 +1,11 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.exception;
+
+public class InvalidRegulationException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+    public static final String ERROR_MSG_TEMPLATE = "Invalid regulation '%s' passed in. Regulation must be one of the following: [PA2023, PCR2015, PCR2006]";
+
+    public InvalidRegulationException(final String regulation) {
+        super(String.format(ERROR_MSG_TEMPLATE, regulation));
+    }
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/mapping/AgreementDetailMapper.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/mapping/AgreementDetailMapper.java
@@ -23,6 +23,8 @@ public interface AgreementDetailMapper {
     @Mapping(source = "benefits", target = "benefits", qualifiedByName = "commercialAgreementBenefitsToStrings")
     @Mapping(source = "lots", target = "lots", qualifiedByName = "lotsToLotSummaries")
     @Mapping(source = "organisationRoles", target = "owner", qualifiedByName = "orgRolesToOrganization")
+    @Mapping(source = "regulation", target = "regulation")
+    @Mapping(source = "agreementType", target = "agreementType", qualifiedByName = "agreementTypeEnumToString")
     AgreementDetail commercialAgreementToAgreementDetail(CommercialAgreement dbModel);
 
     @Mapping(source = "benefits", target = "benefits", qualifiedByName = "stringsToCommercialAgreementBenefits")
@@ -156,6 +158,15 @@ public interface AgreementDetailMapper {
 
                 return model;
             }
+        }
+
+        return null;
+    }
+
+    @Named("agreementTypeEnumToString")
+    public static String agreementTypeEnumToString(AgreementType agreementType) {
+        if (agreementType != null) {
+            return agreementType.getName();
         }
 
         return null;

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/AgreementDetail.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/AgreementDetail.java
@@ -115,34 +115,31 @@ public class AgreementDetail implements Serializable {
 
   public void setAgreementType(String agreementTypeInput) {
 
-    if (agreementTypeInput != null){
-      List<AgreementType> allowList = Arrays.asList();
-      boolean error = false;
-      AgreementType userInputedEnum = AgreementType.getAgreementTypeFromName(agreementTypeInput);
+    if (agreementTypeInput == null) {return;}
 
-      if (userInputedEnum == null) {throw new InvalidAgreementTypeException(agreementTypeInput);};
+    AgreementType userInputedEnum = AgreementType.getAgreementTypeFromName(agreementTypeInput);
+    if (userInputedEnum == null) {throw new InvalidAgreementTypeException(agreementTypeInput);};
 
-      if (this.regulation != null) {
-        switch (this.regulation) {
-          case PA2023:
-            allowList = Arrays.asList(AgreementType.DYNAMIC_MARKET, AgreementType.OPEN_FRAMEWORK, AgreementType.CLOSED_FRAMEWORK);
-            error = !allowList.contains(userInputedEnum);
-            break;
-          case PCR2015:
-            allowList = Arrays.asList(AgreementType.DYNAMIC_PURCHASING_SYSTEM, AgreementType.PCR15_FRAMEWORK);
-            error = !allowList.contains(userInputedEnum);
-            break;
-          case PCR2006:
-            allowList = Arrays.asList(AgreementType.PCR06_FRAMEWORK);
-            error = !allowList.contains(userInputedEnum);
-            break;
-        }
+    if (this.regulation != null) {
+      List<AgreementType> allowedList = getAllowedAgreementTypes(this.regulation);
 
-        if (error) {throw new InvalidAgreementTypeException(AgreementType.getStringFormatForAgreementTypes(allowList), regulation);}
+      if (allowedList == null ||  !allowedList.contains(userInputedEnum)) {throw new InvalidAgreementTypeException(AgreementType.getStringFormatForAgreementTypes(allowedList), regulation);}
 
-        this.agreementType = userInputedEnum;
-      }
+      this.agreementType = userInputedEnum;
     }
   }
+
+  private List<AgreementType> getAllowedAgreementTypes(Regulation regulation) {
+    switch (regulation) {
+        case PA2023:
+            return Arrays.asList(AgreementType.DYNAMIC_MARKET, AgreementType.OPEN_FRAMEWORK, AgreementType.CLOSED_FRAMEWORK);
+        case PCR2015:
+            return Arrays.asList(AgreementType.DYNAMIC_PURCHASING_SYSTEM, AgreementType.PCR15_FRAMEWORK);
+        case PCR2006:
+            return Arrays.asList(AgreementType.PCR06_FRAMEWORK);
+        default:
+          return null;
+    }
+}
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/AgreementDetail.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/AgreementDetail.java
@@ -114,7 +114,6 @@ public class AgreementDetail implements Serializable {
   }
 
   public void setAgreementType(String agreementTypeInput) {
-
     if (agreementTypeInput == null) {return;}
 
     AgreementType userInputedEnum = AgreementType.getAgreementTypeFromName(agreementTypeInput);
@@ -122,9 +121,7 @@ public class AgreementDetail implements Serializable {
 
     if (this.regulation != null) {
       List<AgreementType> allowedList = getAllowedAgreementTypes(this.regulation);
-
       if (allowedList == null ||  !allowedList.contains(userInputedEnum)) {throw new InvalidAgreementTypeException(AgreementType.getStringFormatForAgreementTypes(allowedList), regulation);}
-
       this.agreementType = userInputedEnum;
     }
   }
@@ -140,6 +137,6 @@ public class AgreementDetail implements Serializable {
         default:
           return null;
     }
-}
+  }
 
 }

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/AgreementType.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/AgreementType.java
@@ -1,0 +1,66 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public enum AgreementType {
+
+    @JsonProperty("Dynamic Purchasing System")
+    DYNAMIC_PURCHASING_SYSTEM("Dynamic Purchasing System"),
+
+    @JsonProperty("Dynamic Market")
+    DYNAMIC_MARKET("Dynamic Market"),
+
+    @JsonProperty("Open Framework")
+    OPEN_FRAMEWORK("Open Framework"),
+
+    @JsonProperty("Closed Framework")
+    CLOSED_FRAMEWORK("Closed Framework"),
+
+    @JsonProperty("PCR15 Framework")
+    PCR15_FRAMEWORK("PCR15 Framework"),
+
+    @JsonProperty("PCR06 Framework")
+    PCR06_FRAMEWORK("PCR06 Framework");
+
+    private String name;
+
+    private AgreementType(String name){
+        this.name = name;
+    }
+
+    public String getName(){
+        return this.name;
+    }
+
+    @JsonCreator
+    public static AgreementType getAgreementTypeFromName(String value) {
+
+        for (AgreementType a : AgreementType.values()) {
+            if (a.getName().equalsIgnoreCase(value)) {
+                return a;
+            }
+        }
+
+        return null;
+    }
+
+    public static String getStringFormatForAgreementTypes( List<AgreementType> agreementTypeList){
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("[");
+
+        for (int i = 0; i < agreementTypeList.size(); i++) {
+            sb.append(agreementTypeList.get(i).getName());
+            if (i < agreementTypeList.size() - 1) {
+                sb.append(", ");
+            }
+        }
+
+        sb.append("]");
+
+        return sb.toString();
+    }
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/Regulation.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/dto/Regulation.java
@@ -1,0 +1,41 @@
+package uk.gov.crowncommercial.dts.scale.service.agreements.model.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Regulation
+ */
+public enum Regulation {
+
+    @JsonProperty("PA2023")
+    PA2023("PA2023"),
+
+    @JsonProperty("PCR2015")
+    PCR2015("PCR2015"),
+
+    @JsonProperty("PCR2006")
+    PCR2006("PCR2006");
+
+    private String name;
+
+    private Regulation(String name){
+        this.name = name;
+    }
+
+    public String getName(){
+        return this.name;
+    }
+
+    @JsonCreator
+    public static Regulation getRegulationFromName(String value) {
+
+        for (Regulation r : Regulation.values()) {
+            if (r.getName().equalsIgnoreCase(value)) {
+                return r;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/CommercialAgreement.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/model/entity/CommercialAgreement.java
@@ -12,6 +12,7 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.experimental.FieldDefaults;
 import uk.gov.crowncommercial.dts.scale.service.agreements.exception.InvalidAgreementException;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.*;
 
 /**
  * Commercial Agreement.
@@ -48,6 +49,12 @@ public class CommercialAgreement {
 
   @Column(name = "agreement_url")
   String detailUrl;
+
+  @Column(name = "regulation")
+  String regulation;
+
+  @Column(name = "agreement_type")
+  String agreementType;
 
   @OneToMany(mappedBy = "agreement")
   Set<Lot> lots;
@@ -104,8 +111,7 @@ public class CommercialAgreement {
     if (endDate == null) {throw new InvalidAgreementException("endDate");}
     if (detailUrl == null || detailUrl.isEmpty()) {throw new InvalidAgreementException("detailUrl");}
     if (preDefinedLotRequired == null) {throw new InvalidAgreementException("preDefinedLotRequired");}
-  }
-
+    }
   public CommercialAgreementBenefit addBenefit(CommercialAgreementBenefit benefit){
     this.benefits.add(benefit);
     benefit.setAgreement(this);

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/AgreementService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/AgreementService.java
@@ -73,6 +73,8 @@ public class AgreementService {
             existingModel.setEndDate(model.getEndDate());
             existingModel.setDetailUrl(model.getDetailUrl());
             existingModel.setPreDefinedLotRequired(model.getPreDefinedLotRequired());
+            existingModel.setRegulation(model.getRegulation());
+            existingModel.setAgreementType(model.getAgreementType());
 
             if (model.getBenefits() != null && !model.getBenefits().isEmpty() ){
                 commercialAgreementBenefitService.removeBenefits(existingModel);

--- a/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/WordpressService.java
+++ b/src/main/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/WordpressService.java
@@ -7,6 +7,8 @@ import org.json.JSONTokener;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.AgreementType;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.Regulation;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.CommercialAgreement;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.Lot;
 
@@ -85,11 +87,15 @@ public class WordpressService {
             // We have the data response, so now use it to populate our expansion data
             String agreementDesc = validateWordpressData("summary", jsonData, agreementId);
             String agreementEndDate = validateWordpressData("end_date", jsonData, agreementId);
+            String agreementRegulation = validateWordpressData("regulation", jsonData, agreementId);
+            String agreementType = validateWordpressData("regulation_type", jsonData, agreementId);
 
             if(agreementDesc != null) model.setDescription(agreementDesc);
 
-            // Only override the end date if the service doesn't have one configured - our data is the master data here
+            // Only override if the service doesn't have one configured - our data is the master data here
             if(agreementEndDate != null && model.getEndDate() == null) model.setEndDate(LocalDate.parse(agreementEndDate));
+            if(agreementRegulation != null && model.getRegulation() == null) model.setRegulation(Regulation.getRegulationFromName(agreementRegulation).toString());
+            if(agreementType != null && model.getAgreementType() == null) model.setAgreementType(AgreementType.getAgreementTypeFromName(agreementType).toString());
         }
 
         return model;

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/mapping/MapStructMappingTests.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/mapping/MapStructMappingTests.java
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+
+import uk.gov.crowncommercial.dts.scale.service.agreements.exception.InvalidAgreementTypeException;
+import uk.gov.crowncommercial.dts.scale.service.agreements.exception.InvalidRegulationException;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.*;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.*;
 
@@ -16,8 +19,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static java.lang.String.format;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Note these tests don't cover all aspects of the mapping - they're intended to ensure that mapping functions at a model level, not to cover every possible mapping option
@@ -66,6 +68,11 @@ public class MapStructMappingTests {
     public static final String TEMPLATE_NAME = "Template name";
     public static final Boolean TEMPLATE_MANDATORY = true;
     public static final String TEMPLATE_URL = "http://www.google.com";
+    public static final String INVALID = "SOMETHING_INVALID";
+
+    private static final String INVALID_REGULATION_MESSAGE = "Invalid regulation '%s' passed in. Regulation must be one of the following: [PA2023, PCR2015, PCR2006]";
+    private static final String INVALID_AGREEMENT_TYPE_MESSAGE = "Invalid agreementType '%s' passed in. agreementType must be one of the following: [Dynamic Purchasing System, Dynamic Market, Open Framework, Closed Framework, PCR15 Framework, PCR06 Framework]";
+    private static final String INCOMPATIBLE_AGREEMENT_TYPE_MESSAGE = "agreementType must be one of the following: '%s' for '%s'";
 
     @Test
     public void testCommercialAgreementMapsToAgreementSummary() throws Exception {
@@ -91,6 +98,40 @@ public class MapStructMappingTests {
         assertNotNull(outputModel);
         assertEquals(sourceModel.getName(), outputModel.getName());
         assertEquals(sourceModel.getNumber(), outputModel.getNumber());
+        assertNull(outputModel.getRegulation());
+        assertNull(outputModel.getAgreementType());
+    }
+
+    @Test
+    public void testCommercialAgreementMapsToAgreementDetailWithRegulation() throws Exception {
+        CommercialAgreement sourceModel = new CommercialAgreement();
+        sourceModel.setName(AGREEMENT_NAME);
+        sourceModel.setNumber(AGREEMENT_NUMBER);
+        sourceModel.setRegulation("PA2023");
+
+        AgreementDetail outputModel = agreementDetailMapper.commercialAgreementToAgreementDetail(sourceModel);
+
+        assertNotNull(outputModel);
+        assertEquals(sourceModel.getName(), outputModel.getName());
+        assertEquals(sourceModel.getNumber(), outputModel.getNumber());
+        assertTrue(sourceModel.getRegulation().equalsIgnoreCase(outputModel.getRegulation().getName()));
+    }
+
+    @Test
+    public void testCommercialAgreementMapsToAgreementDetailWithAgreementType() throws Exception {
+        CommercialAgreement sourceModel = new CommercialAgreement();
+        sourceModel.setName(AGREEMENT_NAME);
+        sourceModel.setNumber(AGREEMENT_NUMBER);
+        sourceModel.setRegulation("PA2023");
+        sourceModel.setAgreementType("DYNAMIC_MARKET");
+
+        AgreementDetail outputModel = agreementDetailMapper.commercialAgreementToAgreementDetail(sourceModel);
+
+        assertNotNull(outputModel);
+        assertEquals(sourceModel.getName(), outputModel.getName());
+        assertEquals(sourceModel.getNumber(), outputModel.getNumber());
+        assertTrue(sourceModel.getRegulation().equalsIgnoreCase(outputModel.getRegulation().getName()));
+        assertTrue(sourceModel.getAgreementType().equalsIgnoreCase(outputModel.getAgreementType().toString()));
     }
 
     @Test
@@ -116,12 +157,160 @@ public class MapStructMappingTests {
         assertEquals(sourceModel.getStartDate(), outputModel.getStartDate());
         assertEquals(sourceModel.getEndDate(), outputModel.getEndDate());
         assertEquals(sourceModel.getPreDefinedLotRequired(), outputModel.getPreDefinedLotRequired());
+        assertNull(outputModel.getRegulation());
+        assertNull(outputModel.getAgreementType());
 
         int index = 0;
         for (CommercialAgreementBenefit benefit : outputModel.getBenefits()) {
             assertEquals(benefitArray[index], benefit.getName());
             index++;
         }
+    }
+
+    @Test
+    public void testAgreementDetailMapsToCommercialAgreementWithRegulation() throws Exception {
+        AgreementDetail sourceModel = new AgreementDetail();
+        sourceModel.setName(AGREEMENT_NAME);
+        sourceModel.setNumber(AGREEMENT_NUMBER);
+        sourceModel.setDescription(AGREEMENT_DESCRIPTION);
+        sourceModel.setOwnerName("CCS");
+        sourceModel.setStartDate(java.time.LocalDate.now());
+        sourceModel.setEndDate(java.time.LocalDate.now().plusDays(5));
+        sourceModel.setPreDefinedLotRequired(true);
+        sourceModel.setRegulation("PCR2006");
+
+        CommercialAgreement outputModel = agreementDetailMapper.agreementDetailToCommercialAgreement(sourceModel);
+
+        assertNotNull(outputModel);
+        assertEquals(sourceModel.getName(), outputModel.getName());
+        assertEquals(sourceModel.getNumber(), outputModel.getNumber());
+        assertEquals(sourceModel.getDescription(), outputModel.getDescription());
+        assertEquals(sourceModel.getOwnerName(), outputModel.getOwner());
+        assertEquals(sourceModel.getStartDate(), outputModel.getStartDate());
+        assertEquals(sourceModel.getEndDate(), outputModel.getEndDate());
+        assertEquals(sourceModel.getPreDefinedLotRequired(), outputModel.getPreDefinedLotRequired());
+        assertTrue(outputModel.getRegulation().equalsIgnoreCase(sourceModel.getRegulation().getName()));
+    }
+
+    @Test
+    public void testAgreementDetailMapsToCommercialAgreementWithAgreementType() throws Exception {
+        AgreementDetail sourceModel = new AgreementDetail();
+        sourceModel.setName(AGREEMENT_NAME);
+        sourceModel.setNumber(AGREEMENT_NUMBER);
+        sourceModel.setDescription(AGREEMENT_DESCRIPTION);
+        sourceModel.setOwnerName("CCS");
+        sourceModel.setStartDate(java.time.LocalDate.now());
+        sourceModel.setEndDate(java.time.LocalDate.now().plusDays(5));
+        sourceModel.setPreDefinedLotRequired(true);
+        sourceModel.setRegulation("PCR2006");
+        sourceModel.setAgreementType("PCR06 Framework");
+
+        CommercialAgreement outputModel = agreementDetailMapper.agreementDetailToCommercialAgreement(sourceModel);
+
+        assertNotNull(outputModel);
+        assertEquals(sourceModel.getName(), outputModel.getName());
+        assertEquals(sourceModel.getNumber(), outputModel.getNumber());
+        assertEquals(sourceModel.getDescription(), outputModel.getDescription());
+        assertEquals(sourceModel.getOwnerName(), outputModel.getOwner());
+        assertEquals(sourceModel.getStartDate(), outputModel.getStartDate());
+        assertEquals(sourceModel.getEndDate(), outputModel.getEndDate());
+        assertEquals(sourceModel.getPreDefinedLotRequired(), outputModel.getPreDefinedLotRequired());
+        assertTrue(outputModel.getRegulation().equalsIgnoreCase(sourceModel.getRegulation().getName()));
+        assertTrue(outputModel.getAgreementType().equalsIgnoreCase(sourceModel.getAgreementType().toString()));
+    }
+
+    @Test
+    public void testAgreementDetailMapsToCommercialAgreementWithInvalidRegulation() throws Exception {
+        AgreementDetail sourceModel = new AgreementDetail();
+        sourceModel.setName(AGREEMENT_NAME);
+        sourceModel.setNumber(AGREEMENT_NUMBER);
+        
+        String InvalidRegulation = INVALID;
+
+        Exception exception = assertThrows(InvalidRegulationException.class, () -> {
+            sourceModel.setRegulation(InvalidRegulation);
+        });
+
+        assertEquals(exception.getMessage(), String.format(INVALID_REGULATION_MESSAGE, InvalidRegulation));
+    }
+
+    @Test
+    public void testAgreementDetailMapsToCommercialAgreementWithInvalidAgreementType() throws Exception {
+        AgreementDetail sourceModel = new AgreementDetail();
+        sourceModel.setName(AGREEMENT_NAME);
+        sourceModel.setNumber(AGREEMENT_NUMBER);
+        sourceModel.setRegulation("PCR2006");
+
+        String InvalidAgreementType = INVALID;
+
+        Exception exception = assertThrows(InvalidAgreementTypeException.class, () -> {
+            sourceModel.setAgreementType(InvalidAgreementType);
+        });
+
+        assertEquals(exception.getMessage(), String.format(INVALID_AGREEMENT_TYPE_MESSAGE, InvalidAgreementType));
+    }
+
+    @Test
+    public void testAgreementDetailMapsToCommercialAgreementWithOnlyAgreementType() throws Exception {
+        AgreementDetail sourceModel = new AgreementDetail();
+        sourceModel.setName(AGREEMENT_NAME);
+        sourceModel.setNumber(AGREEMENT_NUMBER);
+        sourceModel.setAgreementType("Dynamic Purchasing System");
+
+        CommercialAgreement outputModel = agreementDetailMapper.agreementDetailToCommercialAgreement(sourceModel);
+
+        assertNotNull(outputModel);
+        assertNull(outputModel.getRegulation());
+        assertNull(outputModel.getAgreementType());
+    }
+
+
+    @Test
+    public void testAgreementDetailMapsToCommercialAgreementWithIncompatibleAgreementType_PCR2006() throws Exception {
+        AgreementDetail sourceModel = new AgreementDetail();
+        String regulation = "PCR2006";
+        
+        sourceModel.setName(AGREEMENT_NAME);
+        sourceModel.setNumber(AGREEMENT_NUMBER);
+        sourceModel.setRegulation(regulation);
+
+        Exception exception = assertThrows(InvalidAgreementTypeException.class, () -> {
+            sourceModel.setAgreementType("Dynamic Purchasing System");
+        });
+
+        assertEquals(exception.getMessage(), String.format(INCOMPATIBLE_AGREEMENT_TYPE_MESSAGE, "[PCR06 Framework]", regulation));
+    }
+
+    @Test
+    public void testAgreementDetailMapsToCommercialAgreementWithIncompatibleAgreementType_PCR2015() throws Exception {
+        AgreementDetail sourceModel = new AgreementDetail();
+        String regulation = "PCR2015";
+        
+        sourceModel.setName(AGREEMENT_NAME);
+        sourceModel.setNumber(AGREEMENT_NUMBER);
+        sourceModel.setRegulation(regulation);
+
+        Exception exception = assertThrows(InvalidAgreementTypeException.class, () -> {
+            sourceModel.setAgreementType("Open Framework");
+        });
+
+        assertEquals(exception.getMessage(), String.format(INCOMPATIBLE_AGREEMENT_TYPE_MESSAGE, "[Dynamic Purchasing System, PCR15 Framework]", regulation));
+    }
+
+    @Test
+    public void testAgreementDetailMapsToCommercialAgreementWithIncompatibleAgreementType_PA2023() throws Exception {
+        AgreementDetail sourceModel = new AgreementDetail();
+        String regulation = "PA2023";
+        
+        sourceModel.setName(AGREEMENT_NAME);
+        sourceModel.setNumber(AGREEMENT_NUMBER);
+        sourceModel.setRegulation(regulation);
+
+        Exception exception = assertThrows(InvalidAgreementTypeException.class, () -> {
+            sourceModel.setAgreementType("Dynamic Purchasing System");
+        });
+
+        assertEquals(exception.getMessage(), String.format(INCOMPATIBLE_AGREEMENT_TYPE_MESSAGE, "[Dynamic Market, Open Framework, Closed Framework]", regulation));
     }
 
     @Test

--- a/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/AgreementServiceTest.java
+++ b/src/test/java/uk/gov/crowncommercial/dts/scale/service/agreements/service/AgreementServiceTest.java
@@ -18,6 +18,8 @@ import uk.gov.crowncommercial.dts.scale.service.agreements.config.EhcacheConfig;
 import uk.gov.crowncommercial.dts.scale.service.agreements.exception.AgreementNotFoundException;
 import uk.gov.crowncommercial.dts.scale.service.agreements.exception.LotNotFoundException;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.AgreementDetail;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.AgreementType;
+import uk.gov.crowncommercial.dts.scale.service.agreements.model.dto.Regulation;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.CommercialAgreement;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.CommercialAgreementBenefit;
 import uk.gov.crowncommercial.dts.scale.service.agreements.model.entity.Lot;
@@ -175,6 +177,34 @@ class AgreementServiceTest {
   }
 
   @Test
+  void testUpdateAgreementWithRegulationAndAgreementType() throws Exception {
+
+    CommercialAgreement result = new CommercialAgreement(AGREEMENT_NUMBER,"Technology Products 2", "CCS", "Short textual description of the commercial agreement", LocalDate.of(2012, 11, 25), java.time.LocalDate.now().plusDays(5), "URL", true);
+    result.setRegulation("PCR2006");
+    result.setAgreementType("PCR06 Framework");
+
+    when(mockCommercialAgreementRepo.findByNumber(AGREEMENT_NUMBER))
+            .thenReturn(Optional.ofNullable(result));
+
+    CommercialAgreement saveAgreement = service.createOrUpdateAgreement(result);
+
+    assertEquals(saveAgreement.getName(), result.getName());
+    assertEquals(saveAgreement.getNumber(), result.getNumber());
+    assertEquals(saveAgreement.getOwner(), result.getOwner());
+    assertEquals(saveAgreement.getDescription(), result.getDescription());
+    assertEquals(saveAgreement.getStartDate(), result.getStartDate());
+    assertEquals(saveAgreement.getEndDate(), result.getEndDate());
+    assertEquals(saveAgreement.getDetailUrl(), result.getDetailUrl());
+    assertEquals(saveAgreement.getBenefits(), result.getBenefits());
+    assertEquals(saveAgreement.getRegulation(), result.getRegulation());
+    assertEquals(saveAgreement.getAgreementType(), result.getAgreementType());
+
+    for (CommercialAgreementBenefit benefit : saveAgreement.getBenefits()) {
+      assertEquals(benefit.getAgreement(), result);
+    }
+  }
+
+  @Test
   void testCreateAgreementWithoutBenefits() throws Exception {
 
     CommercialAgreement input = new CommercialAgreement(AGREEMENT_NUMBER,"Technology Products 2", "CCS", "Short textual description of the commercial agreement", LocalDate.of(2012, 11, 25), java.time.LocalDate.now().plusDays(5), "URL", true);
@@ -192,6 +222,56 @@ class AgreementServiceTest {
     assertEquals(saveAgreement.getEndDate(), result.getEndDate());
     assertEquals(saveAgreement.getDetailUrl(), result.getDetailUrl());
     assertEquals(saveAgreement.getBenefits(), result.getBenefits());
+  }
+
+  @Test
+  void testCreateAgreementWithRegulation() throws Exception {
+
+    CommercialAgreement input = new CommercialAgreement(AGREEMENT_NUMBER,"Technology Products 2", "CCS", "Short textual description of the commercial agreement", LocalDate.of(2012, 11, 25), java.time.LocalDate.now().plusDays(5), "URL", true);
+    CommercialAgreement result = new CommercialAgreement(AGREEMENT_NUMBER,"Technology Products 2", "CCS", "Short textual description of the commercial agreement", LocalDate.of(2012, 11, 25), java.time.LocalDate.now().plusDays(5), "URL", true);
+    input.setRegulation("PCR2015");
+    result.setRegulation("PCR2015");
+
+    when(mockCommercialAgreementRepo.findByNumber(AGREEMENT_NUMBER)).thenReturn(Optional.ofNullable(null)).thenReturn(Optional.of(result));;
+
+    CommercialAgreement saveAgreement = service.createOrUpdateAgreement(input);
+
+    assertEquals(saveAgreement.getName(), result.getName());
+    assertEquals(saveAgreement.getNumber(), result.getNumber());
+    assertEquals(saveAgreement.getOwner(), result.getOwner());
+    assertEquals(saveAgreement.getDescription(), result.getDescription());
+    assertEquals(saveAgreement.getStartDate(), result.getStartDate());
+    assertEquals(saveAgreement.getEndDate(), result.getEndDate());
+    assertEquals(saveAgreement.getDetailUrl(), result.getDetailUrl());
+    assertEquals(saveAgreement.getBenefits(), result.getBenefits());
+    assertEquals(saveAgreement.getRegulation(), result.getRegulation());
+  }
+
+  @Test
+  void testCreateAgreementWithRegulationAndAgreementType() throws Exception {
+
+    CommercialAgreement input = new CommercialAgreement(AGREEMENT_NUMBER,"Technology Products 2", "CCS", "Short textual description of the commercial agreement", LocalDate.of(2012, 11, 25), java.time.LocalDate.now().plusDays(5), "URL", true);
+    CommercialAgreement result = new CommercialAgreement(AGREEMENT_NUMBER,"Technology Products 2", "CCS", "Short textual description of the commercial agreement", LocalDate.of(2012, 11, 25), java.time.LocalDate.now().plusDays(5), "URL", true);
+    input.setRegulation("PCR2015");
+    input.setAgreementType("Closed Framework");
+    result.setRegulation("PCR2015");
+    result.setAgreementType("Closed Framework");
+
+
+    when(mockCommercialAgreementRepo.findByNumber(AGREEMENT_NUMBER)).thenReturn(Optional.ofNullable(null)).thenReturn(Optional.of(result));;
+
+    CommercialAgreement saveAgreement = service.createOrUpdateAgreement(input);
+
+    assertEquals(saveAgreement.getName(), result.getName());
+    assertEquals(saveAgreement.getNumber(), result.getNumber());
+    assertEquals(saveAgreement.getOwner(), result.getOwner());
+    assertEquals(saveAgreement.getDescription(), result.getDescription());
+    assertEquals(saveAgreement.getStartDate(), result.getStartDate());
+    assertEquals(saveAgreement.getEndDate(), result.getEndDate());
+    assertEquals(saveAgreement.getDetailUrl(), result.getDetailUrl());
+    assertEquals(saveAgreement.getBenefits(), result.getBenefits());
+    assertEquals(saveAgreement.getRegulation(), result.getRegulation());
+    assertEquals(saveAgreement.getAgreementType(), result.getAgreementType());
   }
 
   @Test


### PR DESCRIPTION
added 2 new fields and updated the PUT agreement endpoint to take in those 2 fields as optional data and perform validation

```
{
  "name": "Chee's Local Agreement",
  "description": "The primary identifier for this organization or participant. Identifiers that uniquely pick out a legal entity should be preferred. Consult the [organization identifier guidance](https://standard.open-contracting.org/latest/en/schema/identifiers/) for the preferred scheme and identifier to use.",
  "ownerName": "CCS",
  "startDate": "2000-12-31",
  "endDate": "2025-11-23",
  "detailUrl": "https://www.crowncommercial.gov.uk/agreements/RM5678",
  "preDefinedLotRequired": true,
  "regulation": "PA2023",
  "agreementType": "Dynamic Market"
}
```